### PR TITLE
Include actions in intake, IS/IS NOT, and D&C template modes

### DIFF
--- a/docs/storage-schema.appendix.md
+++ b/docs/storage-schema.appendix.md
@@ -13,7 +13,7 @@ The storage schema documentation doubles as the contract for curated template pa
 ### Drawer workflow
 
 - `src/templates.js` normalises template payloads, guaranteeing arrays are cloned and booleans such as `steps.drawerOpen` default to `false`.
-- Mode projections enforce the `MODE_RULES` contract—fields hidden in a mode are reset to safe defaults before the drawer sends state to the app. The KT table honours the same per-column `tableFields` map so IS / IS NOT only prefills IS/IS NOT, D&C adds distinctions/changes while keeping causes/actions empty, and Full exposes all rows plus actions.
+- Mode projections enforce the `MODE_RULES` contract—fields hidden in a mode are reset to safe defaults before the drawer sends state to the app. The KT table honours the same per-column `tableFields` map so IS / IS NOT only prefills IS/IS NOT, D&C adds distinctions/changes while keeping causes empty, and actions are included for every mode while Full exposes all rows plus causes.
 - Actions and steps collections are scrubbed before exposure so tests and runtime code can assume they conform to the schema defined above.
 
 Keeping these guardrails in the appendix allows future guidance for template authors to live beside the generated schema without being overwritten each time the docs regenerate.

--- a/docs/storage-schema.md
+++ b/docs/storage-schema.md
@@ -84,7 +84,7 @@ The storage schema documentation doubles as the contract for curated template pa
 ### Drawer workflow
 
 - `src/templates.js` normalises template payloads, guaranteeing arrays are cloned and booleans such as `steps.drawerOpen` default to `false`.
-- Mode projections enforce the `MODE_RULES` contract—fields hidden in a mode are reset to safe defaults before the drawer sends state to the app. The KT table honours the same per-column `tableFields` map so IS / IS NOT only prefills IS/IS NOT, D&C adds distinctions/changes while keeping causes/actions empty, and Full exposes all rows plus actions.
+- Mode projections enforce the `MODE_RULES` contract—fields hidden in a mode are reset to safe defaults before the drawer sends state to the app. The KT table honours the same per-column `tableFields` map so IS / IS NOT only prefills IS/IS NOT, D&C adds distinctions/changes while keeping causes empty, and actions are included for every mode while Full exposes all rows plus causes.
 - Actions and steps collections are scrubbed before exposure so tests and runtime code can assume they conform to the schema defined above.
 
 Keeping these guardrails in the appendix allows future guidance for template authors to live beside the generated schema without being overwritten each time the docs regenerate.

--- a/src/templateModes.js
+++ b/src/templateModes.js
@@ -60,21 +60,21 @@ export const MODE_RULES = Object.freeze({
     includeTable: false,
     includeCauses: false,
     includeSteps: false,
-    includeActions: false,
+    includeActions: true,
     tableFields: Object.freeze({ is: false, no: false, di: false, ch: false })
   }),
   [TEMPLATE_MODE_IDS.IS_IS_NOT]: Object.freeze({
     includeTable: true,
     includeCauses: false,
     includeSteps: false,
-    includeActions: false,
+    includeActions: true,
     tableFields: Object.freeze({ is: true, no: true, di: false, ch: false })
   }),
   [TEMPLATE_MODE_IDS.DC]: Object.freeze({
     includeTable: true,
     includeCauses: false,
     includeSteps: true,
-    includeActions: false,
+    includeActions: true,
     tableFields: Object.freeze({ is: true, no: true, di: true, ch: true })
   }),
   [TEMPLATE_MODE_IDS.FULL]: Object.freeze({

--- a/tests/templates.unit.test.mjs
+++ b/tests/templates.unit.test.mjs
@@ -189,7 +189,11 @@ test('mode projections follow visibility rules from the manifest', () => {
   assert.equal(intakePayload.table.length, 0, 'intake mode hides the table');
   assert.equal(intakePayload.causes.length, 0, 'intake mode hides causes');
   assert.equal(intakePayload.likelyCauseId, null, 'intake mode removes likely cause selection');
-  assert.equal(intakePayload.actions.analysisId, '', 'intake mode strips actions metadata');
+  assert.equal(
+    intakePayload.actions.analysisId,
+    TEMPLATE_BETA.state.actions.analysisId,
+    'intake mode preserves actions metadata'
+  );
   assert.equal(intakePayload.steps.drawerOpen, false, 'intake mode closes the steps drawer');
 
   const fullPayload = getTemplatePayload(TEMPLATE_BETA.id, TEMPLATE_MODE_IDS.FULL);
@@ -203,8 +207,16 @@ test('mode projections follow visibility rules from the manifest', () => {
   assert.ok(dcPayload);
   assert.equal(dcPayload.causes.length, 0, 'd&c mode hides causes');
   assert.equal(dcPayload.likelyCauseId, null, 'd&c mode removes likely cause selection');
-  assert.equal(dcPayload.actions.analysisId, '', 'd&c mode strips actions metadata');
-  assert.deepEqual(dcPayload.actions.items, [], 'd&c mode hides action items');
+  assert.equal(
+    dcPayload.actions.analysisId,
+    TEMPLATE_BETA.state.actions.analysisId,
+    'd&c mode preserves actions metadata'
+  );
+  assert.deepEqual(
+    dcPayload.actions.items,
+    TEMPLATE_BETA.state.actions.items,
+    'd&c mode preserves action items'
+  );
 });
 
 test('mode projections filter KT table columns per mode', () => {


### PR DESCRIPTION
### Motivation

- Ensure `projectState()` includes `actions` for every template mode so action metadata is available regardless of projection. 
- Align runtime projections with updated expectations that actions should not be stripped from lighter modes. 
- Keep the human-facing mode descriptions intact and confirm they still read correctly after the change.

### Description

- Enable `includeActions: true` in `MODE_RULES` for `intake`, `is-is-not`, and `dc` by updating `src/templateModes.js` so all modes (except none) include actions. 
- Update unit expectations in `tests/templates.unit.test.mjs` to assert that `actions.analysisId` and `actions.items` are preserved for `intake` and `d&c` payloads. 
- Refresh the storage schema guidance in `docs/storage-schema.md` and `docs/storage-schema.appendix.md` to document that actions are included for every mode while causes remain gated by mode.

### Testing

- Ran `npm test -- tests/templates.unit.test.mjs` and the templates-related tests completed successfully. 
- Test summary: `tests: 68`, `pass: 67`, `skip: 1`, `fail: 0` confirming the changes did not break projections or related behaviours.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695e5fbd6778832499d65a488c4da5fc)