### PR TITLE
Preserve Major Incident fields across intake mode switches

### DIFF
--- a/src/appState.js
+++ b/src/appState.js
@@ -69,10 +69,76 @@ import { refreshActionList } from '../components/actions/ActionListCard.js';
 import { applyThemePreference, getThemePreference, normalizeTheme } from './theme.js';
 import { collectHandoverState, applyHandoverState } from './handover.js';
 import { applyIntakeMode, getActiveIntakeMode } from './intakeModeController.js';
+import { INTAKE_MODE_IDS } from './intakeModes.js';
 
 const ANALYSIS_ID_KEY = 'kt-analysis-id';
 let cachedAnalysisId = '';
 const ACTIONS_UPDATED_EVENT = 'intake:actions-updated';
+
+/**
+ * Check whether a nested object owns a specific direct property path.
+ *
+ * @param {object} source - Object to inspect.
+ * @param {string[]} path - Ordered property path to check.
+ * @returns {boolean} Whether every path segment exists as an own property.
+ */
+function hasOwnPath(source, path) {
+  let cursor = source;
+  for (const segment of path) {
+    if (!cursor || typeof cursor !== 'object' || !Object.prototype.hasOwnProperty.call(cursor, segment)) {
+      return false;
+    }
+    cursor = cursor[segment];
+  }
+  return true;
+}
+
+/**
+ * Preserve Major Incident-only data when applying a partial non-MIM mode change.
+ *
+ * @param {Partial<import('./storage.js').SerializedAppState>} incoming - Incoming state payload.
+ * @param {string} appliedMode - Normalized mode already applied to the UI.
+ * @param {object} current - Current hidden field snapshots captured before hydration.
+ * @param {object} current.ops - Current preface operations state.
+ * @param {object} current.comms - Current communications state.
+ * @param {object|null} current.steps - Current steps checklist state.
+ * @param {object} current.handover - Current handover state.
+ * @param {object} ops - Mutable operations payload being applied.
+ * @param {object|null} steps - Candidate steps payload.
+ * @param {object|null} handover - Candidate handover payload.
+ * @returns {{ ops: object, steps: object|null, handover: object|null }} Payload with hidden fields preserved when absent.
+ */
+function preserveHiddenMajorIncidentState(incoming, appliedMode, current, ops, steps, handover) {
+  const hasExplicitModeChange = hasOwnPath(incoming, ['meta', 'intakeMode']) || hasOwnPath(incoming, ['intakeMode']);
+  if (appliedMode === INTAKE_MODE_IDS.MAJOR_INCIDENT && !hasExplicitModeChange) {
+    return { ops, steps, handover };
+  }
+
+  const nextOps = { ...(ops || {}) };
+  const opsDefaults = current?.ops || {};
+  const commDefaults = current?.comms || {};
+  [
+    ['containStatus', opsDefaults.containStatus],
+    ['containDesc', opsDefaults.containDesc],
+    ['commCadence', commDefaults.commCadence],
+    ['commLog', commDefaults.commLog],
+    ['commNextDueIso', commDefaults.commNextDueIso],
+    ['commNextUpdateTime', commDefaults.commNextUpdateTime]
+  ].forEach(([key, value]) => {
+    if (!hasOwnPath(incoming, ['ops', key]) && !hasOwnPath(incoming, [key])) {
+      nextOps[key] = Array.isArray(value) ? value.map(entry => ({ ...entry })) : value;
+    }
+  });
+
+  const nextSteps = hasOwnPath(incoming, ['steps']) || hasOwnPath(incoming, ['stepsState'])
+    ? steps
+    : current.steps;
+  const nextHandover = hasOwnPath(incoming, ['handover'])
+    ? handover
+    : current.handover;
+
+  return { ops: nextOps, steps: nextSteps, handover: nextHandover };
+}
 
 function ensureAnalysisId() {
   if (cachedAnalysisId) {
@@ -184,6 +250,27 @@ export function applyAppState(data = {}) {
   const importedActions = actionsResolution.shouldImport
     ? importActionsState(targetAnalysisId, actionsResolution.items)
     : listActions(targetAnalysisId);
+  const currentHiddenState = {
+    ops: getPrefaceState().ops,
+    comms: getCommunicationsState(),
+    steps: exportStepsState(),
+    handover: collectHandoverState()
+  };
+
+  const appliedTheme = appearanceState && typeof appearanceState.theme === 'string'
+    ? normalizeTheme(appearanceState.theme)
+    : getThemePreference();
+  applyThemePreference(appliedTheme);
+  const appliedMode = applyIntakeMode(data?.meta?.intakeMode ?? data?.intakeMode, { silent: true });
+
+  const preserved = preserveHiddenMajorIncidentState(
+    data,
+    appliedMode,
+    currentHiddenState,
+    ops,
+    steps,
+    savedHandoverState
+  );
   const {
     commCadence = '',
     commLog = [],
@@ -191,13 +278,7 @@ export function applyAppState(data = {}) {
     commNextUpdateTime = '',
     tableFocusMode: savedFocusMode = '',
     ...opsWithoutComms
-  } = ops || {};
-
-  const appliedTheme = appearanceState && typeof appearanceState.theme === 'string'
-    ? normalizeTheme(appearanceState.theme)
-    : getThemePreference();
-  applyThemePreference(appliedTheme);
-  applyIntakeMode(data?.meta?.intakeMode ?? data?.intakeMode, { silent: true });
+  } = preserved.ops || {};
 
   applyPrefaceState({ pre, impact, ops: opsWithoutComms });
   applyCommunicationsState({ commCadence, commLog, commNextDueIso, commNextUpdateTime });
@@ -221,11 +302,11 @@ export function applyAppState(data = {}) {
   }
   updateCauseEvidencePreviews();
 
-  if (steps) {
-    importStepsState(steps);
+  if (preserved.steps) {
+    importStepsState(preserved.steps);
   }
 
-  applyHandoverState(savedHandoverState || {});
+  applyHandoverState(preserved.handover || {});
 
   if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
     try {

--- a/src/comms.js
+++ b/src/comms.js
@@ -6,6 +6,7 @@
  */
 
 let refs = null;
+let refsDocument = null;
 let commLog = [];
 let commCadence = '';
 let commNextDueIso = '';
@@ -22,7 +23,8 @@ let toastHandler = () => {};
  * @returns {Object} Cached reference collection for communications controls.
  */
 function ensureRefs() {
-  if (refs) return refs;
+  if (refs && refsDocument === document) return refs;
+  refsDocument = document;
   const group = document.getElementById('commCadenceGroup');
   refs = {
     internalBtn: document.getElementById('commInternalStampBtn'),

--- a/src/preface.js
+++ b/src/preface.js
@@ -15,6 +15,7 @@ import {
 } from './kt.js';
 
 let refs = null;
+let refsDocument = null;
 let saveHandler = () => {};
 let mirrorTimerId = null;
 let lastObjectValue = '';
@@ -55,7 +56,8 @@ function normalizeContainmentStatus(value) {
  * @returns {Record<string, HTMLElement | null>} Map of reference keys to nodes.
  */
 function ensureRefs() {
-  if (refs) return refs;
+  if (refs && refsDocument === document) return refs;
+  refsDocument = document;
   refs = {
     oneLine: document.getElementById('oneLine'),
     proof: document.getElementById('proof'),

--- a/tests/handover.persistence.feature.test.mjs
+++ b/tests/handover.persistence.feature.test.mjs
@@ -301,3 +301,71 @@ test('handover: summaries include formatted handover section', async () => {
     domSummary.window.close();
   }
 });
+
+test('app state: non-major mode changes preserve hidden Major Incident fields', async () => {
+  const { document } = dom.window;
+  document.body.innerHTML = `
+    <select id="intakeModeSelect">
+      <option value="general">General</option>
+      <option value="majorIncident">Major Incident Management</option>
+    </select>
+    <section data-mode-section="containment">
+      <input type="radio" id="containAssessing" name="containStatus" value="assessing" />
+      <input type="radio" id="containStabilized" name="containStatus" value="stabilized" checked />
+      <input id="containDesc" value="Traffic shifted to standby" />
+    </section>
+    <section data-mode-section="communications">
+      <div id="commCadenceGroup">
+        <input type="radio" name="commCadence" value="15" />
+      </div>
+      <input id="commNextUpdateTime" />
+      <div id="commControlsCard"></div>
+      <div id="commCountdown"></div>
+      <div id="commDueAlert" hidden></div>
+      <ul id="commLogList"></ul>
+      <button id="commLogToggleBtn" hidden></button>
+    </section>
+    <section data-mode-section="steps"><button id="stepsBtn"></button></section>
+    <section id="handover-host" data-mode-section="handover"></section>
+  `;
+  mountHandoverCard(document.getElementById('handover-host'));
+  const handoverSnapshot = populateHandoverSections(document);
+
+  const appStateModule = await import('../src/appState.js?preserve-hidden');
+  const commsModule = await import('../src/comms.js');
+  const stepsModule = await import('../src/steps.js');
+
+  commsModule.applyCommunicationsState({
+    commCadence: '15',
+    commLog: [{ type: 'internal', ts: '2024-01-01T10:00:00Z', message: 'Bridge update sent' }],
+    commNextDueIso: '2024-01-01T10:15:00.000Z',
+    commNextUpdateTime: '10:15'
+  });
+  stepsModule.importStepsState({
+    drawerOpen: false,
+    items: [{ id: '1', label: 'Pre-analysis completed', checked: true }]
+  });
+
+  appStateModule.applyAppState({
+    meta: { intakeMode: 'general' },
+    pre: { oneLine: 'General mode summary' },
+    ops: {}
+  });
+
+  const collected = appStateModule.collectAppState();
+  assert.equal(collected.meta.intakeMode, 'general', 'mode changes to General');
+  assert.equal(document.querySelector('[data-mode-section="communications"]').hidden, true, 'communications UI is hidden');
+  assert.equal(document.querySelector('[data-mode-section="handover"]').hidden, true, 'handover UI is hidden');
+  assert.equal(collected.ops.containStatus, 'stabilized', 'containment status remains persisted');
+  assert.equal(collected.ops.containDesc, 'Traffic shifted to standby', 'containment description remains persisted');
+  assert.equal(collected.ops.commLog.length, 1, 'communications log remains persisted');
+  assert.equal(collected.ops.commLog[0].message, 'Bridge update sent');
+  assert.equal(collected.steps.items.find(item => item.id === '1')?.checked, true, 'steps state remains persisted');
+  assert.deepEqual(collected.handover, handoverSnapshot, 'handover notes remain persisted');
+
+  appStateModule.applyAppState({ meta: { intakeMode: 'majorIncident' } });
+  assert.equal(document.querySelector('[data-mode-section="communications"]').hidden, false, 'communications UI reappears');
+  assert.equal(document.querySelector('[data-mode-section="handover"]').hidden, false, 'handover UI reappears');
+  assert.equal(document.getElementById('containDesc').value, 'Traffic shifted to standby', 'containment description is recoverable');
+  assert.equal(document.querySelector('[data-section="current-state"]')?.value, handoverSnapshot['current-state'].join('\n'), 'handover values are recoverable');
+});


### PR DESCRIPTION
### Motivation
- When switching away from Major Incident Management (MIM) the UI should hide MIM-only regions but not clear their persisted values so users can recover them when switching back. 
- Communications logs, steps checklist state, handover notes, and containment status/description are MIM-specific and must survive non-MIM mode switches. 

### Description
- Add preservation logic in `src/appState.js` (`hasOwnPath`, `preserveHiddenMajorIncidentState`) to merge incoming snapshots with current hidden MIM fields when the incoming payload does not explicitly overwrite them. 
- Capture live hidden-field snapshots before hydration and apply `preserved.ops`, `preserved.steps`, and `preserved.handover` instead of blindly clearing those sections. 
- Refresh cached DOM reference logic in `src/preface.js` and `src/comms.js` so `ensureRefs()` re-queries the active document after remounts (keeps snapshots accurate during tests or DOM swaps). 
- Add a regression integration test `tests/handover.persistence.feature.test.mjs` that verifies switching to a non-major mode hides MIM UI but preserves containment, comms log, steps, and handover data and that switching back restores them. 

### Testing
- Ran the automated test suite with `npm test`; all tests passed (80 passed, 0 failed). 
- Exercised the new regression specifically via the updated `tests/handover.persistence.feature.test.mjs` which validates hide-but-preserve behaviour and recovery when returning to MIM.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a57eb057ee083248d0eb50dc2df2759)