### PR TITLE
Separate IT and Major Incident copy maps

### DIFF
--- a/src/intakeModes.js
+++ b/src/intakeModes.js
@@ -147,14 +147,14 @@ export const INTAKE_MODE_CAPTION_OVERRIDES = deepFreeze({
     impactTime: 'Timing context'
   },
   [INTAKE_MODE_IDS.IT]: {
-    oneLine: 'Incident summary',
-    proof: 'Incident evidence',
+    oneLine: 'Technology operations summary',
+    proof: 'Operational evidence',
     objectPrefill: 'Affected service or component',
-    healthy: 'Known-good service behavior',
+    healthy: 'Expected service behavior',
     now: 'Current service behavior',
     impactNow: 'Current user or system impact',
-    impactFuture: 'Expected escalation risk',
-    impactTime: 'Detection and onset timeline'
+    impactFuture: 'Potential operational risk',
+    impactTime: 'Detection and timing context'
   },
   [INTAKE_MODE_IDS.PHARMA]: {
     oneLine: 'Quality event summary',
@@ -198,13 +198,13 @@ export const INTAKE_MODE_HELPER_OVERRIDES = deepFreeze({
     impactTime: 'Record when the issue started or was first noticed.'
   },
   [INTAKE_MODE_IDS.IT]: {
-    oneLine: 'State the service disruption, scope, and symptom briefly.',
+    oneLine: 'Summarize the technology operations issue, scope, and symptom briefly.',
     proof: 'Capture alerts, customer reports, logs, metrics, or reproduction evidence.',
     objectPrefill: 'Use the service, application, dependency, or infrastructure name.',
     healthy: 'Document the expected technical behavior or SLO baseline.',
-    now: 'Capture the failing behavior, alerts, or user-reported symptom.',
+    now: 'Capture the current behavior, alerts, or user-reported symptom.',
     impactNow: 'Quantify affected users, transactions, regions, or dependencies.',
-    impactFuture: 'Call out likely escalation paths, deadlines, or cascading risks.',
+    impactFuture: 'Call out likely downstream operational risks, deadlines, or dependencies.',
     impactTime: 'Include detection time, suspected start, and recent change windows.'
   },
   [INTAKE_MODE_IDS.PHARMA]: {

--- a/src/summary.js
+++ b/src/summary.js
@@ -47,7 +47,7 @@ const SUMMARY_MODE_CONFIG = Object.freeze({
     includeLikelyCauseSection: false
   }),
   [INTAKE_MODE_IDS.IT]: Object.freeze({
-    prefaceSection: '— Incident Summary —',
+    prefaceSection: '— Technology Operations Summary —',
     impactSection: '— Impact —',
     ktSection: '— Problem Analysis —',
     possibleSection: '— Possible Causes —',

--- a/tests/intakeModes.unit.test.mjs
+++ b/tests/intakeModes.unit.test.mjs
@@ -1,3 +1,6 @@
+/**
+ * @file Verifies intake-mode metadata, visibility, and copy-map contracts.
+ */
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
@@ -58,4 +61,41 @@ test('caption and helper override maps preserve stable field IDs for every mode'
       assert.equal(typeof INTAKE_MODE_FIELD_CAPTIONS[modeId][fieldId].placeholder, 'string');
     });
   });
+});
+
+test('IT and Major Incident use distinct operations and incident copy maps', () => {
+  assert.notDeepEqual(
+    INTAKE_MODE_CAPTION_OVERRIDES[INTAKE_MODE_IDS.IT],
+    INTAKE_MODE_CAPTION_OVERRIDES[INTAKE_MODE_IDS.MAJOR_INCIDENT]
+  );
+  assert.notDeepEqual(
+    INTAKE_MODE_HELPER_OVERRIDES[INTAKE_MODE_IDS.IT],
+    INTAKE_MODE_HELPER_OVERRIDES[INTAKE_MODE_IDS.MAJOR_INCIDENT]
+  );
+
+  const itCopy = [
+    ...Object.values(INTAKE_MODE_CAPTION_OVERRIDES[INTAKE_MODE_IDS.IT]),
+    ...Object.values(INTAKE_MODE_HELPER_OVERRIDES[INTAKE_MODE_IDS.IT])
+  ].join(' ');
+  assert.doesNotMatch(itCopy, /\b(bridge|comms|communications|handover)\b/i);
+  assert.match(itCopy, /technology operations/i);
+
+  const majorIncidentCopy = [
+    ...Object.values(INTAKE_MODE_CAPTION_OVERRIDES[INTAKE_MODE_IDS.MAJOR_INCIDENT]),
+    ...Object.values(INTAKE_MODE_HELPER_OVERRIDES[INTAKE_MODE_IDS.MAJOR_INCIDENT])
+  ].join(' ');
+  assert.match(majorIncidentCopy, /major incident/i);
+  assert.match(majorIncidentCopy, /responders/i);
+  assert.match(majorIncidentCopy, /bridge/i);
+});
+
+test('IT keeps the same minimal visible sections as General and Pharma', () => {
+  assert.deepEqual(
+    INTAKE_MODE_SECTION_VISIBILITY[INTAKE_MODE_IDS.IT],
+    INTAKE_MODE_SECTION_VISIBILITY[INTAKE_MODE_IDS.GENERAL]
+  );
+  assert.deepEqual(
+    INTAKE_MODE_SECTION_VISIBILITY[INTAKE_MODE_IDS.IT],
+    INTAKE_MODE_SECTION_VISIBILITY[INTAKE_MODE_IDS.PHARMA]
+  );
 });

--- a/tests/summary.feature.test.mjs
+++ b/tests/summary.feature.test.mjs
@@ -377,12 +377,12 @@ test('summary: non-major modes use mode labels and exclude major-incident-only s
 
   const text = buildSummaryText(state);
 
-  assert.ok(text.includes('— Incident Summary —'));
-  assert.ok(text.includes('• Incident summary: Checkout payments are failing'));
+  assert.ok(text.includes('— Technology Operations Summary —'));
+  assert.ok(text.includes('• Technology operations summary: Checkout payments are failing'));
   assert.ok(text.includes('• Affected service or component: Payments API'));
   assert.ok(text.includes('Current user or system impact: Customers cannot complete checkout'));
-  assert.ok(text.includes('Expected escalation risk: Backlog may trigger order cancellations'));
-  assert.ok(text.includes('Detection and onset timeline: Detected at 12:45 UTC'));
+  assert.ok(text.includes('Potential operational risk: Backlog may trigger order cancellations'));
+  assert.ok(text.includes('Detection and timing context: Detected at 12:45 UTC'));
   assert.ok(text.includes('— Problem Analysis —'));
   assert.ok(text.includes('— Possible Causes —'));
   assert.ok(text.includes('Likely Cause:'));


### PR DESCRIPTION
### Motivation
- Provide distinct, mode-appropriate wording for the `it` intake mode using technology/operations language and avoid bridge/communications/handover phrasing. 
- Preserve the existing Major Incident copy focused on incident context, responder alignment, bridge timing, containment, and communications. 
- Keep the same minimal visible sections for `it` as used by `general` and `pharma` to maintain a simpler intake surface. 
- Ensure field IDs and storage shapes remain stable so summaries and persistence continue to work unchanged.

### Description
- Updated `src/intakeModes.js` to replace several `it` caption and helper strings with technology operations-focused copy while leaving `majorIncident` text unchanged. 
- Updated `src/summary.js` `SUMMARY_MODE_CONFIG` to render the `it` preface as `— Technology Operations Summary —`. 
- Added unit tests in `tests/intakeModes.unit.test.mjs` that assert `it` and `majorIncident` use distinct caption/helper maps and that `it` shares the same minimal section visibility as `general` and `pharma`. 
- Adjusted `tests/summary.feature.test.mjs` expectations to match the new `it` wording in the generated summary.

### Testing
- Ran `npm test -- tests/intakeModes.unit.test.mjs tests/summary.feature.test.mjs` and the targeted tests passed with no failures. 
- Ran the full test runner as part of the local run and observed all suites passing (no failing tests). 
- Ran `npm run lint -- src/intakeModes.js src/summary.js tests/intakeModes.unit.test.mjs tests/summary.feature.test.mjs` which produced non-blocking warnings but no lint errors. 
- Verified `git diff --check` produced no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a57ed77bee88324830271d71d68b88a)