### PR TITLE
Default fresh intake forms to General

### DIFF
--- a/src/intakeModeController.js
+++ b/src/intakeModeController.js
@@ -26,7 +26,7 @@ let onModeChange = null;
  * Normalize a candidate mode token to a supported mode ID.
  *
  * @param {unknown} mode - Candidate mode value from state, selector, or callers.
- * @returns {string} Supported mode ID, defaulting to Major Incident Management.
+ * @returns {string} Supported mode ID, defaulting to General Intake.
  */
 function normalizeIntakeMode(mode) {
   const candidate = typeof mode === 'string' ? mode.trim() : '';
@@ -46,7 +46,7 @@ function setSectionVisibility(element, shouldShow) {
 }
 
 /**
- * Resolve the current mode from app-state-like payloads or the selector.
+ * Resolve the current mode from app-state-like payloads or the General default.
  *
  * @param {Partial<import('./storage.js').SerializedAppState>} [state] - Optional state snapshot.
  * @returns {string} Supported active intake mode ID.
@@ -55,7 +55,6 @@ function resolveModeFromState(state) {
   return normalizeIntakeMode(
     state?.meta?.intakeMode
       ?? state?.intakeMode
-      ?? activeIntakeMode
       ?? DEFAULT_INTAKE_MODE
   );
 }

--- a/src/intakeModes.js
+++ b/src/intakeModes.js
@@ -2,7 +2,7 @@
  * @module intakeModes
  * @summary Defines reusable intake-mode metadata for tailoring the visible workflow.
  * @description
- *   Exports immutable mode identifiers, display labels, the default backward-compatible
+ *   Exports immutable mode identifiers, display labels, the default scratch-form
  *   intake mode, section visibility flags, and field caption/helper overrides. This
  *   module is configuration-only and manages no DOM anchors; consumers decide how to
  *   apply these settings without altering the protected Kepner-Tregoe row text in
@@ -59,12 +59,12 @@ export const INTAKE_MODE_LABELS = deepFreeze({
 /**
  * Default intake mode used when no explicit mode is stored or selected.
  *
- * Major Incident preserves the existing incident-first experience for callers
- * that predate intake-mode selection.
+ * General keeps new scratch forms lightweight while restored snapshots continue
+ * to apply their saved `meta.intakeMode` value when present.
  *
- * @type {'majorIncident'}
+ * @type {'general'}
  */
-export const DEFAULT_INTAKE_MODE = INTAKE_MODE_IDS.MAJOR_INCIDENT;
+export const DEFAULT_INTAKE_MODE = INTAKE_MODE_IDS.GENERAL;
 
 /**
  * Ordered intake-mode metadata for selectors and documentation surfaces.

--- a/src/storage.js
+++ b/src/storage.js
@@ -101,7 +101,7 @@ const VALID_INTAKE_MODES = new Set(Object.values(INTAKE_MODE_IDS));
 /**
  * Normalizes persisted intake-mode tokens to a supported mode identifier.
  * @param {unknown} mode - Candidate mode value from storage or file imports.
- * @returns {string} Supported mode ID, defaulting to Major Incident Management.
+ * @returns {string} Supported mode ID, defaulting to General Intake.
  */
 function normalizeIntakeMode(mode) {
   const candidate = typeof mode === 'string' ? mode.trim() : '';

--- a/src/summary.js
+++ b/src/summary.js
@@ -269,7 +269,7 @@ function splitLines(text){
 
 /**
  * Resolves the active summary mode from explicit state, saved metadata, or the
- * mounted intake-mode selector while preserving Major Incident as the default.
+ * mounted intake-mode selector while preserving General as the default.
  * @param {object} state - Summary state that may include `meta.intakeMode`.
  * @returns {string} Supported intake mode identifier.
  */
@@ -282,7 +282,7 @@ function resolveSummaryMode(state){
 }
 
 /**
- * Retrieves mode-aware field captions, falling back to Major Incident copy.
+ * Retrieves mode-aware field captions, falling back to General copy.
  * @param {string} mode - Active intake mode identifier.
  * @returns {Readonly<Record<string, {label: string}>>} Caption map for summary labels.
  */

--- a/tests/handover.persistence.feature.test.mjs
+++ b/tests/handover.persistence.feature.test.mjs
@@ -231,6 +231,7 @@ test('handover: summaries include formatted handover section', async () => {
     const summaryModule = await import('../src/summary.js?actual');
     const { buildSummaryText, generateSummary } = summaryModule;
     const summaryState = {
+      meta: { intakeMode: 'majorIncident' },
       docTitle: { textContent: 'Incident with Handover' },
       docSubtitle: { textContent: 'Service instability' },
       oneLine: { value: 'Outage affecting auth flows' },

--- a/tests/intakeModeController.unit.test.mjs
+++ b/tests/intakeModeController.unit.test.mjs
@@ -53,7 +53,7 @@ afterEach(() => {
   delete globalThis.CustomEvent;
 });
 
-test('intake mode controller defaults to Major Incident Management and keeps all sections visible', () => {
+test('intake mode controller defaults to General and hides Major Incident-only regions', () => {
   const document = mountModeDom();
 
   const mode = initIntakeModeController();
@@ -61,8 +61,8 @@ test('intake mode controller defaults to Major Incident Management and keeps all
   assert.equal(mode, DEFAULT_INTAKE_MODE);
   assert.equal(getActiveIntakeMode(), DEFAULT_INTAKE_MODE);
   assert.equal(document.getElementById('intakeModeSelect').value, DEFAULT_INTAKE_MODE);
-  assert.equal(document.querySelector('[data-mode-section="communications"]').hidden, false);
-  assert.equal(document.getElementById('containment').hidden, false);
+  assert.equal(document.querySelector('[data-mode-section="communications"]').hidden, true);
+  assert.equal(document.getElementById('containment').hidden, true);
 });
 
 test('non-major modes hide Major Incident-only regions without unmounting fields', () => {
@@ -131,3 +131,25 @@ test('saved General, IT, Pharma, and Major Incident states restore the active mo
     dom = null;
   });
 });
+
+test('missing and invalid restored modes resolve to General even after another mode was active', () => {
+  let document = mountModeDom();
+  initIntakeModeController({ state: { meta: { intakeMode: INTAKE_MODE_IDS.MAJOR_INCIDENT } } });
+  assert.equal(getActiveIntakeMode(), INTAKE_MODE_IDS.MAJOR_INCIDENT);
+  dom.window.close();
+  dom = null;
+
+  document = mountModeDom();
+  initIntakeModeController({ state: { meta: { intakeMode: 'unsupported-mode' } } });
+  assert.equal(getActiveIntakeMode(), INTAKE_MODE_IDS.GENERAL);
+  assert.equal(document.getElementById('intakeModeSelect').value, INTAKE_MODE_IDS.GENERAL);
+  assert.equal(document.getElementById('commsDrawer').hidden, true);
+
+  dom.window.close();
+  dom = null;
+  document = mountModeDom();
+  initIntakeModeController({ state: { meta: {} } });
+  assert.equal(getActiveIntakeMode(), INTAKE_MODE_IDS.GENERAL);
+  assert.equal(document.getElementById('intakeModeSelect').value, INTAKE_MODE_IDS.GENERAL);
+});
+

--- a/tests/intakeModes.unit.test.mjs
+++ b/tests/intakeModes.unit.test.mjs
@@ -39,7 +39,7 @@ test('intake mode IDs, labels, and default mode are exported for all supported m
     PHARMA: 'pharma',
     MAJOR_INCIDENT: 'majorIncident'
   });
-  assert.equal(DEFAULT_INTAKE_MODE, INTAKE_MODE_IDS.MAJOR_INCIDENT);
+  assert.equal(DEFAULT_INTAKE_MODE, INTAKE_MODE_IDS.GENERAL);
   assert.deepEqual(
     INTAKE_MODES.map(({ id, label }) => [id, label]),
     Object.values(INTAKE_MODE_IDS).map((id) => [id, INTAKE_MODE_LABELS[id]])

--- a/tests/migrateAppState.test.mjs
+++ b/tests/migrateAppState.test.mjs
@@ -176,7 +176,7 @@ test('migrateAppState normalizes persisted intake modes for saved snapshots', ()
   });
 });
 
-test('migrateAppState defaults missing or unknown intake modes to Major Incident Management', () => {
+test('migrateAppState defaults missing or unknown intake modes to General', () => {
   [undefined, '', 'unknown-mode'].forEach((intakeMode) => {
     const migrated = migrateAppState({
       meta: { version: APP_STATE_VERSION, savedAt: null, intakeMode },
@@ -186,6 +186,6 @@ test('migrateAppState defaults missing or unknown intake modes to Major Incident
     });
 
     assert.ok(migrated, 'state should migrate with a normalized mode');
-    assert.equal(migrated.meta.intakeMode, 'majorIncident');
+    assert.equal(migrated.meta.intakeMode, 'general');
   });
 });

--- a/tests/preface.feature.test.mjs
+++ b/tests/preface.feature.test.mjs
@@ -162,8 +162,8 @@ test('preface: mirrors KT fields, normalises containment, and updates titles', a
   objectPrefill.dispatchEvent(new window.Event('input', { bubbles: true }));
 
   assert.equal(objectISField.value, 'Edge Router service');
-  assert.equal(document.getElementById('labelNow').textContent, 'Current deviation');
-  assert.equal(document.getElementById('labelHealthy').textContent, 'Healthy baseline');
+  assert.equal(document.getElementById('labelNow').textContent, 'Current state');
+  assert.equal(document.getElementById('labelHealthy').textContent, 'Expected state');
   assert.equal(document.getElementById('docTitle').textContent, 'KT Intake');
   assert.equal(document.getElementById('docSubtitle').textContent, '');
   assert.equal(document.title, 'KT Intake');
@@ -183,15 +183,15 @@ test('preface: mirrors KT fields, normalises containment, and updates titles', a
   assert.equal(document.getElementById('docTitle').textContent, 'Edge Router service — Traffic drop for users');
   assert.equal(document.getElementById('docSubtitle').textContent, '');
   assert.equal(document.title, 'Edge Router service — Traffic drop for users · KT Intake');
-  assert.equal(document.getElementById('labelHealthy').textContent, 'Healthy baseline');
+  assert.equal(document.getElementById('labelHealthy').textContent, 'Expected state');
 
   deviationISField.value = '';
   nowField.value = '';
   nowField.dispatchEvent(new window.Event('input', { bubbles: true }));
   assert.equal(document.getElementById('docTitle').textContent, 'KT Intake');
   assert.equal(document.getElementById('docSubtitle').textContent, '');
-  assert.equal(document.getElementById('labelNow').textContent, 'Current deviation');
-  assert.equal(document.getElementById('labelHealthy').textContent, 'Healthy baseline');
+  assert.equal(document.getElementById('labelNow').textContent, 'Current state');
+  assert.equal(document.getElementById('labelHealthy').textContent, 'Expected state');
   assert.equal(document.title, 'KT Intake');
 
   objectISField.value = '';
@@ -199,8 +199,8 @@ test('preface: mirrors KT fields, normalises containment, and updates titles', a
   objectPrefill.dispatchEvent(new window.Event('input', { bubbles: true }));
   assert.equal(document.getElementById('docTitle').textContent, 'KT Intake');
   assert.equal(document.getElementById('docSubtitle').textContent, '');
-  assert.equal(document.getElementById('labelNow').textContent, 'Current deviation');
-  assert.equal(document.getElementById('labelHealthy').textContent, 'Healthy baseline');
+  assert.equal(document.getElementById('labelNow').textContent, 'Current state');
+  assert.equal(document.getElementById('labelHealthy').textContent, 'Expected state');
 
   applyPrefaceState({
     ops: { containStatus: 'mitigation' }

--- a/tests/summary.feature.test.mjs
+++ b/tests/summary.feature.test.mjs
@@ -20,6 +20,7 @@ afterEach(() => {
 test('summary: renders populated sections and normalises communication timestamps', () => {
 
   const state = {
+    meta: { intakeMode: 'majorIncident' },
     docTitle: { textContent: 'Major Incident Alpha' },
     docSubtitle: { textContent: 'Payments are timing out' },
     oneLine: { value: 'Card processing failures in NA region' },
@@ -134,6 +135,7 @@ test('summary: renders populated sections and normalises communication timestamp
 test('summary: omits optional sections when inputs are empty', () => {
 
   const state = {
+    meta: { intakeMode: 'majorIncident' },
     docTitle: { textContent: '' },
     docSubtitle: { textContent: '' },
     oneLine: { value: '   ' },


### PR DESCRIPTION
### Motivation
- Make new scratch intake forms default to the lightweight General mode while preserving existing behaviour that restored snapshots continue to use their saved `meta.intakeMode` when present. 
- Ensure callers and UI controllers consistently resolve missing or invalid persisted mode values to the new General default instead of inheriting a previously active mode.

### Description
- Change `DEFAULT_INTAKE_MODE` from `INTAKE_MODE_IDS.MAJOR_INCIDENT` to `INTAKE_MODE_IDS.GENERAL` and update the module JSDoc to describe General as the scratch-form default (`src/intakeModes.js`).
- Update the intake-mode resolution logic so initialization resolves from `state.meta.intakeMode` (or `state.intakeMode`) and falls back directly to `DEFAULT_INTAKE_MODE` without reusing a prior active mode (`src/intakeModeController.js`).
- Update related fallback comments in `src/storage.js` and `src/summary.js` to reflect General as the default fallback.
- Adjust tests and expectations to match the new default and to explicitly include `meta.intakeMode: 'majorIncident'` in summary/handover tests that still expect Major Incident behavior; add a unit test that verifies missing/invalid restored modes resolve to General (`tests/*` updates). 

### Testing
- Ran the automated test suite with `npm test` after updating tests, and all tests passed (no failing tests reported). 
- Ran linting with `npm run lint` and the linter completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a57f9ee12908324b96518441380a903)