### PR TITLE
Move intake mode selector into menu bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,8 @@ Anchors present:
     <div class="header-title">
       <h1 id="docTitle">KT Intake</h1>
       <p class="header-subtitle">Capture incident context, sync updates, and export crisp summaries without leaving the bridge.</p>
+    </div>
+    <nav class="menu-bar" aria-label="Primary menu" role="menubar">
       <!-- [feature:intake-mode-selector] start -->
       <div class="intake-mode-selector field">
         <label for="intakeModeSelect">Intake mode</label>
@@ -55,8 +57,6 @@ Anchors present:
         <small id="intakeModeHelp">Choose the workflow lens before capturing details.</small>
       </div>
       <!-- [feature:intake-mode-selector] end -->
-    </div>
-    <nav class="menu-bar" aria-label="Primary menu" role="menubar">
       <div class="menu-group" data-mode-section="collaboration">
         <button type="button" class="menu-trigger" data-menu-target="collaborationMenu" aria-haspopup="true" aria-expanded="false">Collaboration</button>
         <div class="menu-panel" id="collaborationMenu" role="menu" aria-label="Collaboration" hidden>

--- a/styles.css
+++ b/styles.css
@@ -82,28 +82,23 @@ header{
 h1#docTitle{font-size:22px; font-weight:800; margin:0; letter-spacing:-0.01em; white-space:pre-wrap;}
 .header-subtitle{margin:0; font-size:14px; color:var(--muted); max-width:720px;}
 .intake-mode-selector{
-  width:min(100%, 360px);
-  margin-top:10px;
-  padding:16px;
-  border:1px solid var(--line);
-  border-radius:16px;
-  background:var(--panel);
-  box-shadow:var(--shadow);
+  flex:0 1 280px;
+  min-width:220px;
+  margin:0;
 }
 .intake-mode-selector select{
-  width:100%;
-  box-sizing:border-box;
-  min-height:44px;
-  color:var(--ink);
-  background:var(--input-bg);
-  border:1px solid var(--input-border);
-  border-radius:12px;
-  padding:8px 12px;
-  font:15px/1.55 "SF Pro Text","SF Pro Display",-apple-system,system-ui,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
-  outline:none;
-  transition:border-color var(--speed), box-shadow var(--speed), background var(--speed), color var(--speed);
+  min-height:42px;
 }
-.intake-mode-selector select:focus{border-color:var(--accent); box-shadow:0 0 0 4px var(--focus-ring); background:var(--panel);}
+.menu-bar .intake-mode-selector{
+  align-self:stretch;
+  justify-content:center;
+  padding:0 16px 0 0;
+  border-right:1px solid var(--line);
+}
+.menu-bar .intake-mode-selector small{
+  max-width:260px;
+  line-height:1.35;
+}
 .subtle{color:var(--muted); font-size:12px;}
 .muted{color:var(--muted); font-size:13px;}
 .menu-bar{
@@ -120,6 +115,7 @@ h1#docTitle{font-size:22px; font-weight:800; margin:0; letter-spacing:-0.01em; w
   box-shadow:var(--shadow);
 }
 .menu-group{position:relative;}
+.menu-bar .menu-group{align-self:flex-start;}
 .menu-trigger{
   appearance:none;
   background:var(--panel);
@@ -190,6 +186,8 @@ h1#docTitle{font-size:22px; font-weight:800; margin:0; letter-spacing:-0.01em; w
 @media(max-width:640px){
   header{padding:0 16px;}
   .menu-bar{padding:12px;}
+  .menu-bar .intake-mode-selector{flex:1 1 100%; padding:0 0 12px; border-right:0; border-bottom:1px solid var(--line);}
+  .menu-bar .intake-mode-selector small{max-width:none;}
 }
 .theme-toggle{
   display:flex;

--- a/tests/intakeModeSelector.markup.test.mjs
+++ b/tests/intakeModeSelector.markup.test.mjs
@@ -36,12 +36,16 @@ test('header exposes an accessible intake mode selector with supported modes', (
   ]);
 });
 
-test('intake mode selector stays within the header and preserves required anchors', () => {
+test('intake mode selector stays within the menu bar and preserves required anchors', () => {
   const document = buildIndexDocument();
   const header = document.querySelector('header');
+  const menuBar = document.querySelector('.menu-bar');
+  const headerTitle = document.querySelector('.header-title');
   const selector = document.getElementById('intakeModeSelect');
 
-  assert.ok(header?.contains(selector), 'selector should render near the header title region');
+  assert.ok(header?.contains(selector), 'selector should stay in the header');
+  assert.ok(menuBar?.contains(selector), 'selector should render inside the primary menu bar');
+  assert.equal(headerTitle?.contains(selector), false, 'selector should no longer render inside the header title stack');
   assert.match(INDEX_HTML, /<!-- \[header\] start -->/);
   assert.match(INDEX_HTML, /<!-- \[header\] end -->/);
   assert.match(INDEX_HTML, /<!-- \[section:preface\] start -->/);


### PR DESCRIPTION
### Motivation
- Surface the intake mode selector as a primary header control by moving it into the menu bar so it sits with other global actions while preserving accessibility and the existing anchor contract.

### Description
- Moved the `<!-- [feature:intake-mode-selector] start -->` block from inside `.header-title` into the `<nav class="menu-bar" aria-label="Primary menu" role="menubar">` area while preserving `id="intakeModeSelect"`, `name="intakeMode"`, `aria-describedby="intakeModeHelp"`, all option values, and the feature anchor comments.
- Updated `styles.css` to reuse existing `.field`/select styles and add `.menu-bar .intake-mode-selector` layout rules so the selector aligns with the menu groups and stacks responsively on small screens.
- Adjusted the markup test `tests/intakeModeSelector.markup.test.mjs` to assert the selector now renders inside `.menu-bar` and no longer inside `.header-title`.
- Confirmed `src/intakeModeController.js:initIntakeModeController()` still locates `#intakeModeSelect` and wires the `change` handler to call `applyIntakeMode`.

### Testing
- Ran `npm test -- tests/intakeModeSelector.markup.test.mjs tests/intakeModeController.unit.test.mjs` and both targeted tests passed.
- Ran the full test suite via `npm test` and observed all tests passing (`83` passed, `0` failed, `1` skipped).
- Ran `npm run lint` and the linter completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a57fa375a688324b747b66e9cc7320d)