### PR TITLE
Add containment mode visibility DOM tests

### DIFF
--- a/tests/intakeModeContainment.dom.test.mjs
+++ b/tests/intakeModeContainment.dom.test.mjs
@@ -1,0 +1,78 @@
+/**
+ * @file Verifies production containment group visibility across intake modes.
+ */
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { afterEach, beforeEach, test } from 'node:test';
+import { JSDOM } from 'jsdom';
+
+import { applyIntakeMode } from '../src/intakeModeController.js';
+import { INTAKE_MODE_IDS } from '../src/intakeModes.js';
+import { installJsdomGlobals, restoreJsdomGlobals } from './helpers/jsdom-globals.js';
+
+const INDEX_HTML = readFileSync(new URL('../index.html', import.meta.url), 'utf8');
+
+let dom = null;
+let globalsSnapshot = null;
+
+/**
+ * Mounts the production index markup so mode visibility can be asserted against real DOM hooks.
+ * @returns {Document} Parsed intake document with browser globals installed.
+ */
+function mountIndexDom() {
+  dom = new JSDOM(INDEX_HTML, { url: 'https://example.test/' });
+  globalsSnapshot = installJsdomGlobals(dom.window);
+  return dom.window.document;
+}
+
+/**
+ * Finds the production containment card group and verifies its required fields remain colocated.
+ * @param {Document} document - Mounted intake document.
+ * @returns {HTMLElement} The containment group controlled by intake mode visibility.
+ */
+function getContainmentGroup(document) {
+  const group = document.querySelector('[data-mode-section="containment"].containment-grid');
+
+  assert.ok(group, 'expected the Impact card containment group to keep the containment mode hook and grid class');
+  assert.equal(group.querySelector('legend')?.textContent.trim(), 'Current Service Recovery Stage');
+  assert.ok(group.querySelectorAll('input[type="radio"][name="containStatus"]').length > 0, 'expected containment status radios inside the group');
+  assert.equal(group.querySelector('label[for="containDesc"]')?.textContent.trim(), 'Containment / Mitigation Description');
+  assert.ok(group.querySelector('input#containDesc'), 'expected the containment description input inside the group');
+
+  return group;
+}
+
+beforeEach(() => {
+  mountIndexDom();
+});
+
+afterEach(() => {
+  restoreJsdomGlobals(globalsSnapshot);
+  globalsSnapshot = null;
+  dom?.window.close();
+  dom = null;
+});
+
+test('containment group is hidden for General, IT, and Pharma intake modes', () => {
+  const group = getContainmentGroup(document);
+
+  [
+    INTAKE_MODE_IDS.GENERAL,
+    INTAKE_MODE_IDS.IT,
+    INTAKE_MODE_IDS.PHARMA
+  ].forEach((mode) => {
+    applyIntakeMode(mode, { silent: true });
+
+    assert.equal(group.hidden, true, `${mode} should hide the Impact card containment group`);
+    assert.equal(group.getAttribute('aria-hidden'), 'true', `${mode} should expose hidden state to assistive tech`);
+  });
+});
+
+test('containment group remains visible for Major Incident intake mode', () => {
+  const group = getContainmentGroup(document);
+
+  applyIntakeMode(INTAKE_MODE_IDS.MAJOR_INCIDENT, { silent: true });
+
+  assert.equal(group.hidden, false, 'Major Incident should keep the Impact card containment group visible');
+  assert.equal(group.getAttribute('aria-hidden'), 'false');
+});


### PR DESCRIPTION
### Motivation
- Ensure the Impact card containment group remains hidden for non-major intake modes (General, IT, Pharma) and visible for Major Incident as required by the UI spec.
- Verify the containment group preserves its internal fields (legend, `containStatus` radios, `containDesc` label and input) so persistence/import logic can rely on stable anchors.

### Description
- Add a DOM integration test `tests/intakeModeContainment.dom.test.mjs` that mounts the production `index.html` via `jsdom` and installs browser globals.
- Locate the containment card using the selector `[data-mode-section="containment"].containment-grid` and assert the presence of the legend text, radio inputs named `containStatus`, label `for="containDesc"`, and `input#containDesc`.
- Use `applyIntakeMode()` with `INTAKE_MODE_IDS` to assert the group is hidden (`hidden` + `aria-hidden="true"`) for `general`, `it`, and `pharma`, and visible (`aria-hidden="false"`) for `majorIncident`.
- Include a top-level JSDoc file comment to satisfy lint rules.

### Testing
- Ran `npm run lint -- tests/intakeModeContainment.dom.test.mjs` and lint passed for the new file.
- Ran `npm test` (test runner with the project test-loader) and the new DOM tests executed and all automated tests passed locally with no failures.
- Ran `npm run verify:tests` to ensure coverage guard compatibility and it completed (local diff-aware fallback path exercised while adding the test).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a57fa32a8408324be2f01530b1242e9)