### PR TITLE
Clarify General default intake mode

### DIFF
--- a/src/intakeModes.js
+++ b/src/intakeModes.js
@@ -2,7 +2,7 @@
  * @module intakeModes
  * @summary Defines reusable intake-mode metadata for tailoring the visible workflow.
  * @description
- *   Exports immutable mode identifiers, display labels, the default scratch-form
+ *   Exports immutable mode identifiers, display labels, the default scratch/new-form
  *   intake mode, section visibility flags, and field caption/helper overrides. This
  *   module is configuration-only and manages no DOM anchors; consumers decide how to
  *   apply these settings without altering the protected Kepner-Tregoe row text in
@@ -59,8 +59,9 @@ export const INTAKE_MODE_LABELS = deepFreeze({
 /**
  * Default intake mode used when no explicit mode is stored or selected.
  *
- * General keeps new scratch forms lightweight while restored snapshots continue
- * to apply their saved `meta.intakeMode` value when present.
+ * Scratch and new forms default to General so they stay lightweight while
+ * restored snapshots continue to apply their saved `meta.intakeMode` value
+ * when present.
  *
  * @type {'general'}
  */


### PR DESCRIPTION
### Motivation
- Make the intakemode documentation explicit that scratch/new forms default to General while preserved snapshots continue to apply any saved `meta.intakeMode`.

### Description
- Updated the JSDoc in `src/intakeModes.js` to say "scratch/new forms default to General" and left `DEFAULT_INTAKE_MODE` set to `INTAKE_MODE_IDS.GENERAL` so runtime behaviour is unchanged.
- Verified the primary consumers (`src/intakeModeController.js`, `src/storage.js`, `src/summary.js`, and `src/captionLayer.js`) continue to accept persisted `meta.intakeMode` and only resolve to General for missing/invalid/fresh state.

### Testing
- Ran targeted tests with `npm test -- tests/intakeModes.unit.test.mjs tests/intakeModeController.unit.test.mjs tests/migrateAppState.test.mjs tests/summary.feature.test.mjs` and the suite passed (all tests green).
- Ran the linter with `npm run lint -- src/intakeModes.js src/intakeModeController.js src/storage.js src/summary.js src/captionLayer.js`, which reported pre-existing JSDoc warnings/errors unrelated to this small documentation change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a58082f39888324817eb4a95e5bdc3b)