### PR TITLE
Simplify possible-cause testing panels

### DIFF
--- a/src/kt.js
+++ b/src/kt.js
@@ -1411,28 +1411,6 @@ function updateCauseCardIndicators(card, cause){
 }
 
 /**
- * Formats textarea content into a bullet-style preview for cause testing.
- * @param {string} value - Raw textarea value.
- * @returns {string} Preview text or a dash placeholder.
- */
-function previewEvidenceText(value){
-  const lines = splitLines(value);
-  if(!lines.length) return '—';
-  return lines.map(line => `• ${line}`).join('\n');
-}
-
-/**
- * Splits a block of text into trimmed lines while omitting blanks.
- * @param {string} text - Raw text content.
- * @returns {string[]} Array of non-empty lines.
- */
-function splitLines(text){
-  const v = (text || '').trim();
-  if(!v) return [];
-  return v.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
-}
-
-/**
  * Creates the remove button for a cause card, wiring persistence handlers.
  * @param {PossibleCause} cause - Cause associated with the button.
  * @returns {HTMLButtonElement} Configured remove button element.
@@ -1844,8 +1822,8 @@ export function renderCauses(){
 }
 
 /**
- * Builds the cause testing panel containing question summaries and finding
- * controls.
+ * Builds the cause testing panel containing one compact finding control set
+ * for each eligible KT evidence pair.
  * @param {PossibleCause} cause - Cause being tested.
  * @param {HTMLElement} progressChip - Chip element showing progress counts.
  * @param {HTMLElement} statusEl - Element displaying the status label.
@@ -1856,10 +1834,6 @@ function buildCauseTestPanel(cause, progressChip, statusEl, card){
   const panel = document.createElement('div');
   panel.className = 'cause-test';
   const actionBadge = card?.querySelector('[data-role="action-count"]');
-  const intro = document.createElement('p');
-  intro.className = 'cause-test__intro';
-  intro.textContent = 'For each KT row, choose how this hypothesis handles the IS / IS NOT evidence and document your reasoning.';
-  panel.appendChild(intro);
   if(!rowsBuilt.length){
     const empty = document.createElement('div');
     empty.className = 'cause-empty';
@@ -1884,39 +1858,14 @@ function buildCauseTestPanel(cause, progressChip, statusEl, card){
     rowEl.dataset.rowIndex = index;
     rowEl.dataset.rowKey = rowKey;
     rowEl.hidden = Boolean(row?.tr?.hidden);
+    const dimension = document.createElement('div');
+    dimension.className = 'cause-eval-dimension';
+    dimension.textContent = (row?.th?.textContent || row?.def?.q || '').split('—')[0].trim() || 'KT dimension';
     const qText = document.createElement('div');
     qText.className = 'cause-eval-question-text';
     qText.dataset.role = 'question';
     qText.textContent = buildCauseTestQuestionPrompt(cause, row);
-    rowEl.appendChild(qText);
-    const evidenceWrap = document.createElement('div');
-    evidenceWrap.className = 'cause-evidence-wrap';
-    const isBlock = document.createElement('div');
-    isBlock.className = 'cause-evidence-block';
-    isBlock.dataset.rowIndex = index;
-    isBlock.dataset.type = 'is';
-    const isLabel = document.createElement('span');
-    isLabel.className = 'cause-evidence-label';
-    isLabel.textContent = 'IS evidence';
-    const isValue = document.createElement('div');
-    isValue.className = 'cause-evidence-text';
-    isValue.dataset.role = 'is-value';
-    isValue.textContent = previewEvidenceText(row?.isTA?.value || '');
-    isBlock.append(isLabel, isValue);
-    const notBlock = document.createElement('div');
-    notBlock.className = 'cause-evidence-block';
-    notBlock.dataset.rowIndex = index;
-    notBlock.dataset.type = 'not';
-    const notLabel = document.createElement('span');
-    notLabel.className = 'cause-evidence-label';
-    notLabel.textContent = 'IS NOT evidence';
-    const notValue = document.createElement('div');
-    notValue.className = 'cause-evidence-text';
-    notValue.dataset.role = 'not-value';
-    notValue.textContent = previewEvidenceText(row?.notTA?.value || '');
-    notBlock.append(notLabel, notValue);
-    evidenceWrap.append(isBlock, notBlock);
-    rowEl.appendChild(evidenceWrap);
+    rowEl.append(dimension, qText);
     const inputsWrap = document.createElement('div');
     inputsWrap.className = 'cause-eval-inputs';
     const optionWrap = document.createElement('div');
@@ -2041,7 +1990,7 @@ function buildCauseTestPanel(cause, progressChip, statusEl, card){
 
 /**
  * Synchronizes the cause-testing panels with the latest KT table evidence and
- * action counts.
+ * action counts, including dynamic reasoning prompts.
  * @returns {void}
  */
 export function updateCauseEvidencePreviews(){
@@ -2056,12 +2005,8 @@ export function updateCauseEvidencePreviews(){
     rowEl.hidden = Boolean(row?.tr?.hidden);
     const questionEl = rowEl.querySelector('[data-role="question"]');
     if(questionEl){ questionEl.textContent = buildCauseTestQuestionPrompt(cause, row); }
-    const isValue = rowEl.querySelector('[data-role="is-value"]');
     const rawIs = row?.isTA?.value || '';
     const rawNot = row?.notTA?.value || '';
-    if(isValue){ isValue.textContent = previewEvidenceText(rawIs); }
-    const notValue = rowEl.querySelector('[data-role="not-value"]');
-    if(notValue){ notValue.textContent = previewEvidenceText(rawNot); }
     const noteLabel = rowEl.querySelector('[data-role="note-label"]');
     if(noteLabel && noteLabel.dataset.template){
       noteLabel.textContent = substituteEvidenceTokens(noteLabel.dataset.template, rawIs, rawNot);

--- a/styles.css
+++ b/styles.css
@@ -930,13 +930,9 @@ tbody th{
 }
 .cause-controls{display:flex; gap:8px; flex-wrap:wrap; margin-top:4px;}
 .cause-test{border-top:1px solid #e2e7f3; padding-top:14px; display:flex; flex-direction:column; gap:12px;}
-.cause-test__intro{margin:0; font-size:13px; color:#3b4962;}
 .cause-eval-row{border:1px solid #e3e8f5; border-radius:12px; background:#f9fbff; padding:14px; display:flex; flex-direction:column; gap:12px;}
+.cause-eval-dimension{font-size:11px; text-transform:uppercase; letter-spacing:.08em; color:#7a8398; font-weight:700;}
 .cause-eval-question-text{font-weight:600; font-size:13px; color:#1f2b40;}
-.cause-evidence-wrap{display:grid; gap:10px; grid-template-columns:repeat(auto-fit, minmax(180px,1fr));}
-.cause-evidence-block{display:flex; flex-direction:column; gap:4px; padding:10px; border-radius:10px; background:#ffffff; border:1px solid #e6ebf5;}
-.cause-evidence-label{font-size:11px; text-transform:uppercase; letter-spacing:.08em; color:#7a8398; font-weight:700;}
-.cause-evidence-text{font-size:13px; line-height:1.5; color:#22324b; white-space:pre-line;}
 .cause-eval-inputs{display:flex; flex-direction:column; gap:12px;}
 .cause-eval-options{display:flex; flex-wrap:wrap; gap:8px;}
 .cause-eval-option{appearance:none; border:1px solid #dfe5f2; background:#ffffff; color:#1d2845; font-weight:600; font-size:13px; padding:8px 14px; border-radius:999px; cursor:pointer; transition:background var(--speed), border-color var(--speed), color var(--speed), box-shadow var(--speed);}
@@ -946,7 +942,6 @@ tbody th{
 .cause-eval-note{display:flex; flex-direction:column; gap:6px;}
 .cause-eval-note[hidden]{display:none;}
 .cause-eval-inputs .field textarea{min-height:120px;}
-.cause-evidence-empty{padding:12px; border-radius:10px; background:#f7f9ff; color:#5b6475; font-size:13px;}
 @media (max-width:720px){
   .cause-card{padding:16px;}
 }

--- a/tests/kt-causes.feature.test.mjs
+++ b/tests/kt-causes.feature.test.mjs
@@ -1,7 +1,7 @@
 /**
  * KT possible causes integration tests.
  *
- * Validates that cause testing UI renders expected evidence previews,
+ * Validates that cause testing UI renders compact verdict controls,
  * action badges, and toast/save callbacks when users manipulate
  * Likely Cause state.
  */
@@ -183,16 +183,17 @@ test('kt causes: refreshes action badges from mocked counts', async () => {
   assert.equal(listActionsMock.mock.calls[0].arguments[0], 'analysis-test');
 });
 
-test('kt causes: updates evidence previews and emits toast/save callbacks', async () => {
+test('kt causes: renders compact verdict controls and preserves finding callbacks', async () => {
   const ktModule = await loadKtModule();
   const rows = ktModule.getRowsBuilt();
   rows.length = 0;
 
   const saveSpy = mock.fn();
   const toastSpy = mock.fn();
-  ktModule.configureKT({ autoResize: () => {}, onSave: saveSpy, showToast: toastSpy });
+  const resizeSpy = mock.fn();
+  ktModule.configureKT({ autoResize: resizeSpy, onSave: saveSpy, showToast: toastSpy });
 
-  const cause = { id: 'cause-a', suspect: 'Alpha subsystem', accusation: 'is failing health checks', findings: {} };
+  const cause = { id: 'cause-a', suspect: 'Alpha subsystem', accusation: 'is failing health checks', findings: {}, testingOpen: true };
   ktModule.setPossibleCauses([cause]);
 
   const isTextarea = document.createElement('textarea');
@@ -201,63 +202,44 @@ test('kt causes: updates evidence previews and emits toast/save callbacks', asyn
   notTextarea.value = 'Beta detail';
   rows.push({
     tr: { hidden: false },
-    th: { textContent: 'Where is it failing?' },
+    th: { textContent: 'WHERE — Where is it failing?' },
     def: { q: 'Where is {OBJECT} misbehaving?' },
     isTA: isTextarea,
     notTA: notTextarea
   });
 
-  const causeList = document.getElementById('causeList');
-  const rowEl = document.createElement('section');
-  rowEl.className = 'cause-eval-row';
-  rowEl.dataset.rowIndex = '0';
+  ktModule.renderCauses();
 
-  const questionEl = document.createElement('div');
-  questionEl.dataset.role = 'question';
+  const rowEl = document.querySelector('.cause-eval-row');
+  const questionEl = rowEl.querySelector('[data-role="question"]');
+  const noteField = rowEl.querySelector('.cause-eval-note');
+  const noteLabel = rowEl.querySelector('[data-role="note-label"]');
+  const noteInput = rowEl.querySelector('[data-role="finding-note"]');
+  const verdicts = rowEl.querySelectorAll('.cause-eval-option');
+  const findingKey = ktModule.getRowKeyByIndex(0);
 
-  const evidenceWrap = document.createElement('div');
-  const isValue = document.createElement('div');
-  isValue.dataset.role = 'is-value';
-  const notValue = document.createElement('div');
-  notValue.dataset.role = 'not-value';
-  evidenceWrap.append(isValue, notValue);
+  assert.equal(rowEl.querySelector('.cause-eval-dimension').textContent, 'WHERE');
+  assert.equal(questionEl.textContent, 'If Alpha subsystem is failing health checks, how does it explain WHERE — Where is it failing?');
+  assert.equal(verdicts.length, 3, 'each evidence pair gets exactly three verdict controls');
+  assert.equal(noteField.hidden, true, 'reasoning is hidden until a verdict is selected');
+  assert.equal(rowEl.querySelector('[data-role="is-value"]'), null, 'IS evidence cards are not rendered');
+  assert.equal(rowEl.querySelector('[data-role="not-value"]'), null, 'IS NOT evidence cards are not rendered');
 
-  const inputsWrap = document.createElement('div');
-  const noteField = document.createElement('div');
-  const noteLabel = document.createElement('label');
-  noteLabel.dataset.role = 'note-label';
-  noteLabel.dataset.template = 'Explain <is> vs <is not>';
-  const noteInput = document.createElement('textarea');
-  noteInput.dataset.role = 'finding-note';
-  noteField.append(noteLabel, noteInput);
-  inputsWrap.append(noteField);
+  verdicts[1].click();
+  assert.equal(cause.findings[findingKey].mode, 'yes');
+  assert.equal(noteField.hidden, false);
+  assert.match(noteLabel.textContent, /Alpha detail/);
+  assert.match(noteLabel.textContent, /Beta detail/);
 
-  rowEl.append(questionEl, evidenceWrap, inputsWrap);
-  const card = document.createElement('div');
-  card.className = 'cause-card';
-  card.dataset.causeId = cause.id;
-  card.append(rowEl);
-  causeList.append(card);
+  noteInput.value = 'It matches the observed region.';
+  noteInput.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+  assert.equal(cause.findings[findingKey].note, 'It matches the observed region.');
+  assert.ok(resizeSpy.mock.calls.length > 0, 'autosize runs for the conditional textarea');
+  assert.ok(saveSpy.mock.calls.length >= 2, 'verdict and reasoning changes retain save callbacks');
 
-  ktModule.updateCauseEvidencePreviews();
-
-  assert.equal(questionEl.textContent, 'If Alpha subsystem is failing health checks, how does it explain Where is it failing?');
-  assert.equal(isValue.textContent, '• Alpha detail');
-  assert.equal(notValue.textContent, '• Beta detail');
-  assert.equal(noteLabel.textContent, 'Explain Alpha detail vs Beta detail');
-  assert.equal(noteInput.placeholder, '');
-
-  isTextarea.value = 'Alpha detail\nDelta factor';
-  notTextarea.value = '';
-  ktModule.updateCauseEvidencePreviews();
-
-  assert.equal(isValue.textContent, '• Alpha detail\n• Delta factor');
-  assert.equal(notValue.textContent, '—');
-  assert.equal(noteLabel.textContent, 'Explain Alpha detail\nDelta factor vs IS NOT column');
-  assert.equal(noteInput.placeholder, '');
-
+  const savesBeforeLikelyCause = saveSpy.mock.calls.length;
   ktModule.setLikelyCauseId('cause-a', { skipRender: true });
-  assert.equal(saveSpy.mock.calls.length, 1, 'setLikelyCauseId triggers the save callback');
+  assert.equal(saveSpy.mock.calls.length, savesBeforeLikelyCause + 1, 'setLikelyCauseId triggers the save callback');
   assert.equal(toastSpy.mock.calls.length, 1, 'setLikelyCauseId emits a toast message');
   assert.equal(toastSpy.mock.calls[0].arguments[0], 'Likely Cause set to: Alpha subsystem.');
 });


### PR DESCRIPTION
### Motivation
- Reduce visual noise in the cause-testing panel by surfacing a compact verdict UI per eligible KT evidence pair. 
- Remove duplicated IS / IS NOT evidence cards from the testing panel while keeping the underlying evidence capture in the KT table unchanged. 
- Preserve existing persistence, autosize, and completion behaviour so downstream state and summaries remain compatible.

### Description
- Refactored `buildCauseTestPanel()` in `src/kt.js` to render, for each eligible evidence pair, a dimension label, a single generated comparison question, three verdict controls, and one conditional reasoning `textarea`, while retaining `cause.testingOpen`, `findings`, save callbacks, `evidencePairIndexes()`, autosize calls, and the mode-plus-note completion rule. 
- Removed the separate IS / IS NOT evidence-card markup from the testing panel and retired the related evidence-card CSS rules in `styles.css` (added a lightweight `.cause-eval-dimension` style). 
- Updated integration coverage in `tests/kt-causes.feature.test.mjs` to assert that each eligible pair renders exactly three verdict controls, does not render the IS/IS NOT cards, shows the conditional reasoning textarea when a verdict is chosen, and that verdict/reasoning changes trigger the existing save/autosize callbacks. 
- Modified files: `src/kt.js`, `styles.css`, and `tests/kt-causes.feature.test.mjs`.

### Testing
- Ran `npm test` and the full test suite, which completed successfully. 
- Ran the repository check `npm run verify:tests` which passed against the updated tests. 
- Ran `git diff --check` (whitespace/check validation) which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5a4d331568832485f4da4c245673ac)