### PR TITLE
Add row-specific cause-test prompts

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -21,6 +21,7 @@
  * @property {('p1'|'p2')} [priority] - Visual priority indicator for the row.
  * @property {string} [isPH] - Prompt for what is happening (Positive Hypothesis).
  * @property {string} [notPH] - Prompt for what is not happening (Negative Hypothesis).
+ * @property {CauseTestMetadata} [causeTest] - Row-specific cause-testing prompt metadata.
  */
 
 /**
@@ -67,12 +68,57 @@ function deepFreeze(obj) {
   return Object.freeze(obj);
 }
 
+/**
+ * @typedef {Object} CauseTestMetadata
+ * @property {string} template - Prompt template with `{cause}`, `{problem}`,
+ * `{is}`, and `{isNot}` placeholders.
+ */
+
+/**
+ * Cause-test prompt templates keyed by the stable KT question identifiers.
+ * Each template frames the distinction represented by the corresponding row.
+ * @type {Record<string, CauseTestMetadata>}
+ */
+export const CAUSE_TEST_METADATA = deepFreeze({
+  'what-object': {
+    template: 'If {cause}, why is {problem} seen on {is} but not on {isNot}?'
+  },
+  'what-deviation': {
+    template: 'If {cause}, why does {problem} present as {is} rather than {isNot}?'
+  },
+  'where-location': {
+    template: 'If {cause}, why does {problem} occur at {is} but not at {isNot}?'
+  },
+  'where-on-object': {
+    template: 'If {cause}, why is {problem} observed on {is} but not on {isNot}?'
+  },
+  'when-first-observed': {
+    template: 'If {cause}, why was {problem} first observed at {is} rather than {isNot}?'
+  },
+  'when-pattern': {
+    template: 'If {cause}, why does {problem} follow the pattern {is} but not {isNot}?'
+  },
+  'when-description': {
+    template: 'If {cause}, why does {problem} appear {is} but not {isNot}?'
+  },
+  'extent-population': {
+    template: 'If {cause}, why does {problem} affect {is} but not {isNot}?'
+  },
+  'extent-size': {
+    template: 'If {cause}, why is {problem} {is} rather than {isNot}?'
+  },
+  'extent-count': {
+    template: 'If {cause}, why does {problem} occur {is} rather than {isNot}?'
+  }
+});
+
 /** @type {RowDefinition[]} */
 const ROWS_UNFROZEN = [
   { band: "WHAT", note: "Define the problem precisely (Object & Deviation)." },
 
   {
     id: 'what-object',
+    causeTest: CAUSE_TEST_METADATA['what-object'],
     q: "WHAT — Specific Object/Thing is having the {DEVIATION}",
     priority: 'p1',
     isPH:
@@ -82,6 +128,7 @@ const ROWS_UNFROZEN = [
   },
   {
     id: 'what-deviation',
+    causeTest: CAUSE_TEST_METADATA['what-deviation'],
     q: "WHAT — Specific Deviation does the {OBJECT} have?",
     priority: 'p1',
     isPH:
@@ -94,6 +141,7 @@ const ROWS_UNFROZEN = [
 
   {
     id: 'where-location',
+    causeTest: CAUSE_TEST_METADATA['where-location'],
     q: "WHERE — is the {OBJECT} geographically/topology when the {DEVIATION} occurs?",
     priority: 'p1',
     isPH:
@@ -103,6 +151,7 @@ const ROWS_UNFROZEN = [
   },
   {
     id: 'where-on-object',
+    causeTest: CAUSE_TEST_METADATA['where-on-object'],
     q: "WHERE — On the {OBJECT} is the {DEVIATION} observed?",
     priority: 'p2',
     isPH:
@@ -115,6 +164,7 @@ const ROWS_UNFROZEN = [
 
   {
     id: 'when-first-observed',
+    causeTest: CAUSE_TEST_METADATA['when-first-observed'],
     q: "WHEN — Was the {DEVIATION} First observed for {OBJECT}",
     priority: 'p2',
     isPH:
@@ -124,6 +174,7 @@ const ROWS_UNFROZEN = [
   },
   {
     id: 'when-pattern',
+    causeTest: CAUSE_TEST_METADATA['when-pattern'],
     q: "WHEN — Since the first occurrence has {DEVIATION} been logged? What Pattern?",
     isPH:
       "Since first occurrence, when does {DEVIATION} re-occur?\n• What Pattern (continuous/periodic/sporadic/one time)",
@@ -132,6 +183,7 @@ const ROWS_UNFROZEN = [
   },
   {
     id: 'when-description',
+    causeTest: CAUSE_TEST_METADATA['when-description'],
     q: "WHEN — Describe using words When the {DEVIATION} was first seen",
     isPH:
       "At what point in {OBJECT}’s life-cycle did {DEVIATION} appear?\n• Use words like before, during, or after to describe these times and consider multiple lifecycles",
@@ -143,6 +195,7 @@ const ROWS_UNFROZEN = [
 
   {
     id: 'extent-population',
+    causeTest: CAUSE_TEST_METADATA['extent-population'],
     q: "EXTENT — What is the population or size of {OBJECT} affected?",
     isPH:
       "How many {OBJECT}s have {DEVIATION}?\nTrend (↑/↓/stable)?",
@@ -151,6 +204,7 @@ const ROWS_UNFROZEN = [
   },
   {
     id: 'extent-size',
+    causeTest: CAUSE_TEST_METADATA['extent-size'],
     q: "EXTENT — What is the size of a single {DEVIATION}?",
     isPH:
       "How big is a single {DEVIATION} on {OBJECT}?\nTrend (↑/↓/stable)?",
@@ -159,6 +213,7 @@ const ROWS_UNFROZEN = [
   },
   {
     id: 'extent-count',
+    causeTest: CAUSE_TEST_METADATA['extent-count'],
     q: "EXTENT — How many {DEVIATION} are occuring on each {OBJECT}?",
     isPH:
       "How many instances of {DEVIATION} per {OBJECT}?\nTrend (↑/↓/stable)?",

--- a/src/kt.js
+++ b/src/kt.js
@@ -56,28 +56,80 @@ function defaultGetDeviationFull(){
 }
 
 /**
- * Builds a standardized cause-testing question tying the hypothesis to a KT row.
+ * Builds the normalized hypothesis phrase used in cause-testing prompts.
  * @param {PossibleCause} [cause] - Cause supplying suspect and accusation context.
- * @param {KTRowBinding} [row] - KT row binding containing the question prompt.
- * @returns {string} Prompt framed to explain how the hypothesis addresses the row.
+ * @returns {string} Cause phrase suitable for insertion after "If".
  */
-function buildCauseTestQuestionPrompt(cause, row){
+function buildCausePhrase(cause){
   const suspectClean = normalizeHypothesisValue(cause?.suspect || '');
   const suspectText = suspectClean || 'this cause';
   const accusationClean = normalizeHypothesisValue(cause?.accusation || '');
-  const hasAccusation = Boolean(accusationClean);
   const accusationNormalized = normalizeAccusation(accusationClean);
   const suspectIsPlural = /\b(?:and|&)\b/iu.test(suspectText)
     || /s$/iu.test((suspectText.split(/\s+/u).pop() || '').replace(/[^a-z]/giu, ''));
-  const accusationClauseRaw = hasAccusation
+  const accusationClauseRaw = accusationClean
     ? buildDirectAccusationClause(accusationNormalized, suspectIsPlural)
     : (suspectIsPlural ? 'are causing the deviation' : 'is causing the deviation');
   const accusationClause = trimValue(accusationClauseRaw) && accusationClauseRaw !== '…'
     ? accusationClauseRaw.trim()
     : (suspectIsPlural ? 'are causing the deviation' : 'is causing the deviation');
-  const rowQuestion = row?.th?.textContent?.trim() || fillTokens(row?.def?.q || '') || 'this KT row';
-  const questionClean = rowQuestion.replace(/[?]+$/u, '').trim() || 'this KT row';
-  return `If ${suspectText} ${accusationClause}, how does it explain ${questionClean}?`;
+  return `${suspectText} ${accusationClause}`;
+}
+
+/**
+ * Builds the object-and-deviation phrase used in cause-testing prompts.
+ * @returns {string} Problem phrase based on the current KT problem definition.
+ */
+function buildProblemPhrase(){
+  const object = firstSnippet(objectIS?.value) || firstSnippet(getObjectFullFn());
+  const deviation = firstSnippet(deviationIS?.value) || firstSnippet(getDeviationFullFn());
+  if(!object || !deviation) return '';
+  return `the issue affecting ${object} (${deviation})`;
+}
+
+/**
+ * Applies a cause-test template with its hypothesis, problem, and evidence values.
+ * @param {string} template - Row-specific template containing named placeholders.
+ * @param {Record<string, string>} values - Replacement values for the template.
+ * @returns {string} Filled prompt, or an empty string when a value cannot fit naturally.
+ */
+function applyCauseTestTemplate(template, values){
+  if(typeof template !== 'string' || !template.trim()) return '';
+  const requiredTokens = ['cause', 'problem', 'is', 'isNot'];
+  if(requiredTokens.some(token => !values[token])) return '';
+  let prompt = template;
+  requiredTokens.forEach(token => {
+    prompt = prompt.replaceAll(`{${token}}`, values[token]);
+  });
+  return /\{(?:cause|problem|is|isNot)\}/u.test(prompt) ? '' : prompt.trim();
+}
+
+/**
+ * Builds the row-specific cause-testing question without rendering separate
+ * evidence cards. Falls back to one generic evidence-aware question when a
+ * row template or a natural problem phrase is unavailable.
+ * @param {PossibleCause} [cause] - Cause supplying suspect and accusation context.
+ * @param {KTRowBinding} [row] - KT row binding containing metadata and evidence.
+ * @returns {string} Prompt that connects the cause to the IS / IS NOT distinction.
+ */
+function buildCauseTestPrompt(cause, row){
+  const causePhrase = buildCausePhrase(cause);
+  const problemPhrase = buildProblemPhrase();
+  const isValue = trimValue(row?.isTA?.value || '');
+  const isNotValue = trimValue(row?.notTA?.value || '');
+  const template = row?.def?.causeTest?.template;
+  const prompt = applyCauseTestTemplate(template, {
+    cause: causePhrase,
+    problem: problemPhrase,
+    is: isValue,
+    isNot: isNotValue
+  });
+  if(prompt) return prompt;
+
+  const genericProblem = problemPhrase || 'the problem';
+  const genericIs = isValue || 'the observed IS evidence';
+  const genericIsNot = isNotValue || 'the IS NOT evidence';
+  return `If ${causePhrase}, how does that explain ${genericProblem} is ${genericIs} but not ${genericIsNot}?`;
 }
 
 let autoResize = defaultAutoResize;
@@ -1864,7 +1916,7 @@ function buildCauseTestPanel(cause, progressChip, statusEl, card){
     const qText = document.createElement('div');
     qText.className = 'cause-eval-question-text';
     qText.dataset.role = 'question';
-    qText.textContent = buildCauseTestQuestionPrompt(cause, row);
+    qText.textContent = buildCauseTestPrompt(cause, row);
     rowEl.append(dimension, qText);
     const inputsWrap = document.createElement('div');
     inputsWrap.className = 'cause-eval-inputs';
@@ -2004,7 +2056,7 @@ export function updateCauseEvidencePreviews(){
     const cause = possibleCauses.find(item => item.id === causeId);
     rowEl.hidden = Boolean(row?.tr?.hidden);
     const questionEl = rowEl.querySelector('[data-role="question"]');
-    if(questionEl){ questionEl.textContent = buildCauseTestQuestionPrompt(cause, row); }
+    if(questionEl){ questionEl.textContent = buildCauseTestPrompt(cause, row); }
     const rawIs = row?.isTA?.value || '';
     const rawNot = row?.notTA?.value || '';
     const noteLabel = rowEl.querySelector('[data-role="note-label"]');

--- a/tests/kt-causes.feature.test.mjs
+++ b/tests/kt-causes.feature.test.mjs
@@ -10,6 +10,7 @@ import { after, afterEach, before, beforeEach, mock, test } from 'node:test';
 import { JSDOM } from 'jsdom';
 
 import { installJsdomGlobals, restoreJsdomGlobals } from './helpers/jsdom-globals.js';
+import { CAUSE_TEST_METADATA, ROWS } from '../src/constants.js';
 
 const BASE_HTML = `
 <!doctype html>
@@ -146,6 +147,21 @@ after(() => {
   previousGlobals = {};
 });
 
+test('KT rows: define immutable cause-test metadata for every stable question ID', () => {
+  const questionRows = ROWS.filter(row => row.id);
+
+  assert.deepEqual(
+    questionRows.map(row => row.id),
+    Object.keys(CAUSE_TEST_METADATA),
+    'metadata keys stay aligned with persisted question IDs'
+  );
+  questionRows.forEach(row => {
+    assert.equal(row.causeTest, CAUSE_TEST_METADATA[row.id]);
+    assert.match(row.causeTest.template, /\{cause\}.*\{problem\}.*\{is\}.*\{isNot\}/u);
+    assert.equal(Object.isFrozen(row.causeTest), true);
+  });
+});
+
 test('kt causes: refreshes action badges from mocked counts', async () => {
   const ktModule = await loadKtModule();
   const rows = ktModule.getRowsBuilt();
@@ -191,7 +207,13 @@ test('kt causes: renders compact verdict controls and preserves finding callback
   const saveSpy = mock.fn();
   const toastSpy = mock.fn();
   const resizeSpy = mock.fn();
-  ktModule.configureKT({ autoResize: resizeSpy, onSave: saveSpy, showToast: toastSpy });
+  ktModule.configureKT({
+    autoResize: resizeSpy,
+    onSave: saveSpy,
+    showToast: toastSpy,
+    getObjectFull: () => 'payment service',
+    getDeviationFull: () => 'timeouts'
+  });
 
   const cause = { id: 'cause-a', suspect: 'Alpha subsystem', accusation: 'is failing health checks', findings: {}, testingOpen: true };
   ktModule.setPossibleCauses([cause]);
@@ -203,7 +225,10 @@ test('kt causes: renders compact verdict controls and preserves finding callback
   rows.push({
     tr: { hidden: false },
     th: { textContent: 'WHERE — Where is it failing?' },
-    def: { q: 'Where is {OBJECT} misbehaving?' },
+    def: {
+      q: 'Where is {OBJECT} misbehaving?',
+      causeTest: CAUSE_TEST_METADATA['where-location']
+    },
     isTA: isTextarea,
     notTA: notTextarea
   });
@@ -219,7 +244,7 @@ test('kt causes: renders compact verdict controls and preserves finding callback
   const findingKey = ktModule.getRowKeyByIndex(0);
 
   assert.equal(rowEl.querySelector('.cause-eval-dimension').textContent, 'WHERE');
-  assert.equal(questionEl.textContent, 'If Alpha subsystem is failing health checks, how does it explain WHERE — Where is it failing?');
+  assert.equal(questionEl.textContent, 'If Alpha subsystem is failing health checks, why does the issue affecting payment service (timeouts) occur at Alpha detail but not at Beta detail?');
   assert.equal(verdicts.length, 3, 'each evidence pair gets exactly three verdict controls');
   assert.equal(noteField.hidden, true, 'reasoning is hidden until a verdict is selected');
   assert.equal(rowEl.querySelector('[data-role="is-value"]'), null, 'IS evidence cards are not rendered');
@@ -256,11 +281,18 @@ test('kt causes: renders standardized testing prompts for plural suspects', asyn
   rows.push({
     tr: { hidden: false },
     th: { textContent: 'When does it occur?' },
-    def: { q: 'When does the {OBJECT} show the {DEVIATION}?' },
+    def: {
+      q: 'When does the {OBJECT} show the {DEVIATION}?',
+      causeTest: CAUSE_TEST_METADATA['when-pattern']
+    },
     isTA: isTextarea,
     notTA: notTextarea
   });
 
+  ktModule.configureKT({
+    getObjectFull: () => 'checkout API',
+    getDeviationFull: () => 'latency spikes'
+  });
   ktModule.setPossibleCauses([
     { id: 'cause-b', suspect: 'API nodes', accusation: 'were throttled overnight', findings: {}, testingOpen: true }
   ]);
@@ -269,7 +301,41 @@ test('kt causes: renders standardized testing prompts for plural suspects', asyn
 
   const questionEl = document.querySelector('.cause-eval-row [data-role="question"]');
   assert.ok(questionEl, 'question prompt renders');
-  assert.equal(questionEl.textContent, 'If API nodes were throttled overnight, how does it explain When does it occur?');
+  assert.equal(questionEl.textContent, 'If API nodes were throttled overnight, why does the issue affecting checkout API (latency spikes) follow the pattern Cache nodes at AZ-1 but not Cache nodes at AZ-2?');
+});
+
+test('kt causes: uses one generic evidence-aware prompt when a row cannot use metadata', async () => {
+  const ktModule = await loadKtModule();
+  const rows = ktModule.getRowsBuilt();
+  rows.length = 0;
+
+  const isTextarea = document.createElement('textarea');
+  const notTextarea = document.createElement('textarea');
+  isTextarea.value = 'cluster A';
+  notTextarea.value = 'cluster B';
+  rows.push({
+    tr: { hidden: false },
+    def: { q: 'Custom diagnostic question' },
+    isTA: isTextarea,
+    notTA: notTextarea
+  });
+  ktModule.configureKT({
+    getObjectFull: () => '',
+    getDeviationFull: () => ''
+  });
+  ktModule.setPossibleCauses([
+    { id: 'cause-fallback', suspect: 'A cache rule', accusation: 'is misconfigured', findings: {}, testingOpen: true }
+  ]);
+
+  ktModule.renderCauses();
+
+  const rowEl = document.querySelector('.cause-eval-row');
+  assert.equal(
+    rowEl.querySelector('[data-role="question"]').textContent,
+    'If A cache rule is misconfigured, how does that explain the problem is cluster A but not cluster B?'
+  );
+  assert.equal(rowEl.querySelector('[data-role="is-value"]'), null);
+  assert.equal(rowEl.querySelector('[data-role="not-value"]'), null);
 });
 
 test('kt causes: hypothesis editor normalizes inputs and stores summary metadata', async () => {


### PR DESCRIPTION
### Motivation
- Provide row-specific cause-testing prompts keyed to the existing stable KT question IDs so cause-test wording can be tailored per-dimension. 
- Ensure cause-test prompts can interpolate a normalized cause phrase, a problem phrase derived from the current `OBJECT`/`DEVIATION`, and the row's IS / IS NOT evidence, with a single generic fallback when natural interpolation is not possible. 

### Description
- Add an immutable `CAUSE_TEST_METADATA` map in `src/constants.js` and attach a `causeTest` reference to each question row using the stable IDs (`what-object`, `what-deviation`, `where-location`, `where-on-object`, `when-first-observed`, `when-pattern`, `when-description`, `extent-population`, `extent-size`, `extent-count`). 
- Introduce helpers in `src/kt.js`: `buildCausePhrase`, `buildProblemPhrase`, `applyCauseTestTemplate`, and `buildCauseTestPrompt`, and replace prior usage of `buildCauseTestQuestionPrompt` with `buildCauseTestPrompt` so prompts are rendered by applying the row-specific template (or a single evidence-aware fallback) without reintroducing separate IS/IS NOT evidence cards. 
- Wire the new prompt builder into the cause-testing panel (`buildCauseTestPanel`) and live preview refresh (`updateCauseEvidencePreviews`) so prompts update as evidence or context changes. 
- Update integration tests in `tests/kt-causes.feature.test.mjs` to assert metadata alignment/immutability, row-specific interpolation, fallback behaviour, and that no separate evidence cards are rendered.

### Testing
- Ran `npm run lint -- --no-fix` and the lint pass completed successfully. 
- Ran `npm test` and the test suite completed with all new and existing tests passing (no failures). 
- Ran `npm run verify:tests` (coverage guard) which completed using the working-tree fallback and passed. 
- Attempted `npx --yes playwright@1.55.0 install chromium` to provision browser tooling for screenshots, but the install failed due to a registry permission (HTTP 403) which is unrelated to the unit/integration test outcomes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5a4cf933d08324ab73fa13b55f38b1)