### PR TITLE
Render cause-finding verdicts as accessible radio choices (yes / assumption / fail)

### DIFF
--- a/src/kt.js
+++ b/src/kt.js
@@ -1920,8 +1920,12 @@ function buildCauseTestPanel(cause, progressChip, statusEl, card){
     rowEl.append(dimension, qText);
     const inputsWrap = document.createElement('div');
     inputsWrap.className = 'cause-eval-inputs';
-    const optionWrap = document.createElement('div');
+    const optionWrap = document.createElement('fieldset');
     optionWrap.className = 'cause-eval-options';
+    const optionLegend = document.createElement('legend');
+    optionLegend.className = 'cause-eval-options-legend';
+    optionLegend.textContent = `Verdict for ${dimension.textContent} evidence`;
+    optionWrap.appendChild(optionLegend);
     const noteField = document.createElement('div');
     noteField.className = 'field cause-eval-note';
     noteField.hidden = true;
@@ -1949,27 +1953,28 @@ function buildCauseTestPanel(cause, progressChip, statusEl, card){
 
     const optionDefs = [
       {
-        mode: CAUSE_FINDING_MODES.ASSUMPTION,
-        buttonLabel: 'Explains Only if…',
-        noteLabel: 'What assumptions are necessary to explain why we see it on the <is> and not the <is not>?'
-      },
-      {
         mode: CAUSE_FINDING_MODES.YES,
-        buttonLabel: 'Yes, because…',
+        buttonLabel: 'Explains Naturally',
         noteLabel: 'How does this naturally explain that we see <is> and that we don\'t see <is not>?'
       },
       {
+        mode: CAUSE_FINDING_MODES.ASSUMPTION,
+        buttonLabel: 'Requires Assumptions',
+        noteLabel: 'What assumptions are necessary to explain why we see it on the <is> and not the <is not>?'
+      },
+      {
         mode: CAUSE_FINDING_MODES.FAIL,
-        buttonLabel: 'Does not explain…',
+        buttonLabel: 'Does Not Explain',
         noteLabel: 'Why can\'t we explain the <is> being present, but not the <is not>?'
       }
     ];
-    const buttons = [];
+    const options = [];
+    const optionGroupName = `cause-finding-${cause.id}-${rowKey}`;
     const rawIs = row?.isTA?.value || '';
     const rawNot = row?.notTA?.value || '';
 
     /**
-     * Updates button selection and note fields based on the chosen mode.
+     * Updates radio selection and note fields based on the chosen mode.
      * @param {string} newMode - Mode to activate.
      * @param {object} [opts] - Behavior flags for the update.
      * @param {boolean} [opts.silent] - When true prevents persistence and toast
@@ -1978,8 +1983,10 @@ function buildCauseTestPanel(cause, progressChip, statusEl, card){
      */
     function applyMode(newMode, opts = {}){
       const active = isValidFindingMode(newMode) ? newMode : '';
-      buttons.forEach(btn => {
-        btn.element.classList.toggle('is-selected', btn.mode === active);
+      options.forEach(option => {
+        const isSelected = option.mode === active;
+        option.input.checked = isSelected;
+        option.element.classList.toggle('is-selected', isSelected);
       });
       if(active){
         const config = optionDefs.find(def => def.mode === active);
@@ -2011,24 +2018,21 @@ function buildCauseTestPanel(cause, progressChip, statusEl, card){
     }
 
     optionDefs.forEach(def => {
-      const btn = document.createElement('button');
-      btn.type = 'button';
-      btn.className = 'cause-eval-option';
-      btn.textContent = def.buttonLabel;
-      btn.dataset.mode = def.mode;
-      btn.addEventListener('click', () => {
-        const entry = getCauseFinding(cause, rowKey);
-        const current = findingMode(entry);
-        if(current === def.mode){
-          setCauseFindingValue(cause, rowKey, 'mode', '');
-          applyMode('');
-        }else{
-          setCauseFindingValue(cause, rowKey, 'mode', def.mode);
-          applyMode(def.mode);
-        }
+      const option = document.createElement('label');
+      option.className = 'cause-eval-option';
+      option.dataset.mode = def.mode;
+      const input = document.createElement('input');
+      input.type = 'radio';
+      input.name = optionGroupName;
+      input.value = def.mode;
+      input.addEventListener('change', () => {
+        if(!input.checked) return;
+        setCauseFindingValue(cause, rowKey, 'mode', def.mode);
+        applyMode(def.mode);
       });
-      optionWrap.appendChild(btn);
-      buttons.push({ element: btn, mode: def.mode });
+      option.append(input, document.createTextNode(def.buttonLabel));
+      optionWrap.appendChild(option);
+      options.push({ element: option, input, mode: def.mode });
     });
 
     const startingMode = findingMode(finding);

--- a/styles.css
+++ b/styles.css
@@ -934,10 +934,12 @@ tbody th{
 .cause-eval-dimension{font-size:11px; text-transform:uppercase; letter-spacing:.08em; color:#7a8398; font-weight:700;}
 .cause-eval-question-text{font-weight:600; font-size:13px; color:#1f2b40;}
 .cause-eval-inputs{display:flex; flex-direction:column; gap:12px;}
-.cause-eval-options{display:flex; flex-wrap:wrap; gap:8px;}
-.cause-eval-option{appearance:none; border:1px solid #dfe5f2; background:#ffffff; color:#1d2845; font-weight:600; font-size:13px; padding:8px 14px; border-radius:999px; cursor:pointer; transition:background var(--speed), border-color var(--speed), color var(--speed), box-shadow var(--speed);}
+.cause-eval-options{border:0; margin:0; padding:0; display:flex; flex-wrap:wrap; gap:8px;}
+.cause-eval-options-legend{width:100%; margin-bottom:2px; padding:0; color:#56627a; font-size:12px; font-weight:600;}
+.cause-eval-option{border:1px solid #dfe5f2; background:#ffffff; color:#1d2845; font-weight:600; font-size:13px; padding:8px 14px; border-radius:999px; cursor:pointer; display:inline-flex; align-items:center; gap:8px; transition:background var(--speed), border-color var(--speed), color var(--speed), box-shadow var(--speed);}
+.cause-eval-option input{margin:0; accent-color:var(--accent);}
 .cause-eval-option:hover{border-color:var(--accent);}
-.cause-eval-option:focus{outline:none; border-color:var(--accent); box-shadow:0 0 0 4px rgba(0,122,255,.18);}
+.cause-eval-option:focus-within{outline:none; border-color:var(--accent); box-shadow:0 0 0 4px rgba(0,122,255,.18);}
 .cause-eval-option.is-selected{background:rgba(0,122,255,.12); border-color:var(--accent); color:var(--accent); box-shadow:0 6px 16px rgba(0,122,255,.12);}
 .cause-eval-note{display:flex; flex-direction:column; gap:6px;}
 .cause-eval-note[hidden]{display:none;}

--- a/tests/kt-causes.feature.test.mjs
+++ b/tests/kt-causes.feature.test.mjs
@@ -241,24 +241,38 @@ test('kt causes: renders compact verdict controls and preserves finding callback
   const noteLabel = rowEl.querySelector('[data-role="note-label"]');
   const noteInput = rowEl.querySelector('[data-role="finding-note"]');
   const verdicts = rowEl.querySelectorAll('.cause-eval-option');
+  const verdictInputs = rowEl.querySelectorAll('.cause-eval-option input[type="radio"]');
   const findingKey = ktModule.getRowKeyByIndex(0);
 
   assert.equal(rowEl.querySelector('.cause-eval-dimension').textContent, 'WHERE');
   assert.equal(questionEl.textContent, 'If Alpha subsystem is failing health checks, why does the issue affecting payment service (timeouts) occur at Alpha detail but not at Beta detail?');
   assert.equal(verdicts.length, 3, 'each evidence pair gets exactly three verdict controls');
+  assert.equal(rowEl.querySelector('.cause-eval-options').tagName, 'FIELDSET', 'verdict controls are an accessible choice group');
+  assert.deepEqual(
+    [...verdictInputs].map(input => [input.value, input.parentElement.textContent]),
+    [
+      ['yes', 'Explains Naturally'],
+      ['assumption', 'Requires Assumptions'],
+      ['fail', 'Does Not Explain']
+    ],
+    'verdicts retain the prescribed values, labels, and order'
+  );
+  assert.equal(new Set([...verdictInputs].map(input => input.name)).size, 1, 'verdict radios share one exclusive-choice group');
   assert.equal(noteField.hidden, true, 'reasoning is hidden until a verdict is selected');
   assert.equal(rowEl.querySelector('[data-role="is-value"]'), null, 'IS evidence cards are not rendered');
   assert.equal(rowEl.querySelector('[data-role="not-value"]'), null, 'IS NOT evidence cards are not rendered');
 
-  verdicts[1].click();
+  verdictInputs[0].click();
   assert.equal(cause.findings[findingKey].mode, 'yes');
   assert.equal(noteField.hidden, false);
+  assert.equal(ktModule.countCompletedEvidence(cause), 0, 'a verdict alone does not complete a finding');
   assert.match(noteLabel.textContent, /Alpha detail/);
   assert.match(noteLabel.textContent, /Beta detail/);
 
   noteInput.value = 'It matches the observed region.';
   noteInput.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
   assert.equal(cause.findings[findingKey].note, 'It matches the observed region.');
+  assert.equal(ktModule.countCompletedEvidence(cause), 1, 'a finding is complete only after its note is supplied');
   assert.ok(resizeSpy.mock.calls.length > 0, 'autosize runs for the conditional textarea');
   assert.ok(saveSpy.mock.calls.length >= 2, 'verdict and reasoning changes retain save callbacks');
 


### PR DESCRIPTION
### Motivation
- The cause-testing UI should present the three verdicts as a single accessible, exclusive-choice group with the specified labels and order while keeping persisted mode values intact.
- Preserve the existing completion rule that a finding is only complete when both a `mode` and a `note` are provided.

### Description
- Replace per-verdict buttons with a semantic `fieldset` of radio inputs so each evidence row exposes one exclusive choice group implemented as `fieldset`/`legend` and ordered radio `input`s.
- Render the options in the exact persisted-value order and labels: `yes` / `Explains Naturally`, `assumption` / `Requires Assumptions`, and `fail` / `Does Not Explain`, without changing `CAUSE_FINDING_MODES` or persisted values in `src/constants.js`.
- Wire radio `change` handlers to call the existing `setCauseFindingValue()` and reuse `applyMode()` so existing persistence, progress updates, and save callbacks remain unchanged.
- Update `styles.css` to style the new radio-based controls and adjust focus styles to use `:focus-within` for accessible keyboard focus.
- Add assertions in `tests/kt-causes.feature.test.mjs` to verify the `fieldset` semantics, option values/labels/order, radio-group exclusivity, and that a finding only counts as complete after a note is supplied.

### Testing
- Ran `npm test -- tests/kt-causes.feature.test.mjs` and the test passed (suite pass for the updated feature test).
- Ran `npm run lint` and `npm run verify:tests` which both completed successfully with no lint or verification failures.
- Ran `npm run build` and `git diff --check` to ensure templates/build and whitespace checks succeeded.
- The updated unit/feature test validates semantics and the preserved completion rule and passed in CI-local run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5a7590a894832497bb63c8083d7b3d)