### PR TITLE
Add starter reasoning for cause findings

### DIFF
--- a/src/kt.js
+++ b/src/kt.js
@@ -215,6 +215,18 @@ const TABLE_MODE_ROWS = Object.freeze({
 const DEFAULT_TABLE_FOCUS_MODE = 'rapid';
 
 /**
+ * Initial reasoning text supplied when a finding verdict is selected. These
+ * starters give each verdict an actionable explanation prompt and satisfy the
+ * existing non-empty reasoning requirement until the analyst refines them.
+ * @type {Readonly<Record<string, string>>}
+ */
+const CAUSE_FINDING_NOTE_STARTERS = Object.freeze({
+  [CAUSE_FINDING_MODES.YES]: 'This cause naturally explains the IS / IS NOT relationship because ',
+  [CAUSE_FINDING_MODES.ASSUMPTION]: 'This explanation requires assuming that ',
+  [CAUSE_FINDING_MODES.FAIL]: 'This cause does not explain the IS / IS NOT relationship because '
+});
+
+/**
  * Row prompts whose Distinctions/Changes fields should appear semi-disabled.
  * @type {Set<string>}
  */
@@ -1983,6 +1995,9 @@ function buildCauseTestPanel(cause, progressChip, statusEl, card){
      */
     function applyMode(newMode, opts = {}){
       const active = isValidFindingMode(newMode) ? newMode : '';
+      const priorMode = findingMode(getCauseFinding(cause, rowKey));
+      const priorStarter = CAUSE_FINDING_NOTE_STARTERS[priorMode] || '';
+      const canReplaceNote = !priorMode || noteInput.value === priorStarter;
       options.forEach(option => {
         const isSelected = option.mode === active;
         option.input.checked = isSelected;
@@ -1997,6 +2012,11 @@ function buildCauseTestPanel(cause, progressChip, statusEl, card){
         delete noteInput.dataset.placeholderTemplate;
         noteInput.disabled = false;
         noteField.hidden = false;
+        if(!opts.silent && active !== priorMode && canReplaceNote){
+          const starter = CAUSE_FINDING_NOTE_STARTERS[active] || '';
+          noteInput.value = starter;
+          setCauseFindingValue(cause, rowKey, 'note', starter);
+        }
       }else{
         noteLabel.textContent = '';
         delete noteLabel.dataset.template;
@@ -2005,7 +2025,12 @@ function buildCauseTestPanel(cause, progressChip, statusEl, card){
         noteInput.value = '';
         noteInput.disabled = true;
         noteField.hidden = true;
-        setCauseFindingValue(cause, rowKey, 'note', '');
+        if(!opts.silent){
+          setCauseFindingValue(cause, rowKey, 'note', '');
+        }
+      }
+      if(!opts.silent){
+        setCauseFindingValue(cause, rowKey, 'mode', active);
       }
       autoResize(noteInput);
       if(!opts.silent){
@@ -2027,7 +2052,6 @@ function buildCauseTestPanel(cause, progressChip, statusEl, card){
       input.value = def.mode;
       input.addEventListener('change', () => {
         if(!input.checked) return;
-        setCauseFindingValue(cause, rowKey, 'mode', def.mode);
         applyMode(def.mode);
       });
       option.append(input, document.createTextNode(def.buttonLabel));

--- a/tests/kt-causes.feature.test.mjs
+++ b/tests/kt-causes.feature.test.mjs
@@ -265,7 +265,13 @@ test('kt causes: renders compact verdict controls and preserves finding callback
   verdictInputs[0].click();
   assert.equal(cause.findings[findingKey].mode, 'yes');
   assert.equal(noteField.hidden, false);
-  assert.equal(ktModule.countCompletedEvidence(cause), 0, 'a verdict alone does not complete a finding');
+  assert.equal(
+    noteInput.value,
+    'This cause naturally explains the IS / IS NOT relationship because ',
+    'the selected verdict supplies its reasoning starter'
+  );
+  assert.equal(cause.findings[findingKey].note, noteInput.value, 'the reasoning starter persists with the finding');
+  assert.equal(ktModule.countCompletedEvidence(cause), 1, 'a verdict with non-empty starter reasoning completes a finding');
   assert.match(noteLabel.textContent, /Alpha detail/);
   assert.match(noteLabel.textContent, /Beta detail/);
 
@@ -273,6 +279,23 @@ test('kt causes: renders compact verdict controls and preserves finding callback
   noteInput.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
   assert.equal(cause.findings[findingKey].note, 'It matches the observed region.');
   assert.equal(ktModule.countCompletedEvidence(cause), 1, 'a finding is complete only after its note is supplied');
+
+  verdictInputs[1].click();
+  assert.equal(
+    noteInput.value,
+    'It matches the observed region.',
+    'changing verdicts preserves user-modified reasoning'
+  );
+
+  noteInput.value = 'This explanation requires assuming that ';
+  noteInput.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+  verdictInputs[2].click();
+  assert.equal(
+    noteInput.value,
+    'This cause does not explain the IS / IS NOT relationship because ',
+    'changing a mode replaces only the prior mode starter'
+  );
+  assert.equal(cause.findings[findingKey].note, noteInput.value, 'the replacement starter persists with the finding');
   assert.ok(resizeSpy.mock.calls.length > 0, 'autosize runs for the conditional textarea');
   assert.ok(saveSpy.mock.calls.length >= 2, 'verdict and reasoning changes retain save callbacks');
 


### PR DESCRIPTION
### Motivation
- Provide a helpful, opinionated starter for each cause-finding verdict so analysts get an actionable prompt and the UI can treat non-empty starter text as temporary reasoning until refined.
- Replace starters only when the previous note exactly matched the prior mode starter so analyst-edited notes are preserved across mode changes.

### Description
- Added a frozen `CAUSE_FINDING_NOTE_STARTERS` map in `src/kt.js` with starters for `CAUSE_FINDING_MODES.YES`, `CAUSE_FINDING_MODES.ASSUMPTION`, and `CAUSE_FINDING_MODES.FAIL`.
- Updated the conditional textarea logic inside `buildCauseTestPanel()` / `applyMode()` to assign the appropriate starter to `noteInput.value` on initial mode selection and persist it with `setCauseFindingValue(cause, rowKey, 'note', value)` while keeping existing autosize, UI updates, and save behavior.
- On mode change, the code now checks the current note against the prior mode starter and only replaces it when unchanged, preserving any user-modified reasoning; the `mode` is persisted when not `opts.silent`.
- Updated tests in `tests/kt-causes.feature.test.mjs` to verify starter insertion, persistence, user-edit preservation, and replacement behavior; modified files: `src/kt.js`, `tests/kt-causes.feature.test.mjs`.

### Testing
- Ran the focused suite with `node --test --loader ./tests/test-loader.mjs tests/kt-causes.feature.test.mjs` and verified the updated scenarios passed.
- Ran the full test and verification commands `npm test`, `npm run lint`, and `npm run verify:tests`, and they completed successfully in the local run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5a786f6d8c83248d2dc814448a1c8f)