### PR TITLE
Question-led intake prompts for General/IT/Pharma/Major Incident; update fallbacks and tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,7 +249,7 @@ Anchors present:
         <h3>Problem Summary</h3>
         <div class="grid">
           <div class="field">
-            <label for="oneLine">In one sentence, what service or capability is not working right now?</label>
+            <label for="oneLine">What issue is affecting the service or capability, and how is it degraded?</label>
             <textarea id="oneLine" placeholder="" rows="2"></textarea>
           </div>
         </div>
@@ -306,14 +306,14 @@ Anchors present:
         <div class="grid cols-2">
           <div data-mode-section="incidentProof">
             <div class="field">
-              <label for="proof">What concrete evidence proves a deviation from normal behavior?</label>
-              <small>Examples: alerts, error messages, metric spikes/drops, log lines, screenshots, reproducible steps.</small>
+              <label for="proof">What observable or measurable evidence confirms a deviation from normal?</label>
+              <small>Which alerts, observations, measurements, reports, or reproducible results demonstrate the deviation?</small>
               <textarea id="proof" placeholder=""></textarea>
             </div>
           </div>
           <div class="field">
-            <label for="objectPrefill">Which specific service or component (object) is affected?</label>
-            <small>Hardware name and model, Function/Module/Method, Container/Service/API, datastore/volume/bucket/table, network element, identity/policy/role, pipeline/job.</small>
+            <label for="objectPrefill">Which specific object is affected, and what identifies it?</label>
+            <small>Which service, process, tool, machine, model, or configuration details distinguish the affected object?</small>
             <textarea id="objectPrefill" placeholder=""></textarea>
           </div>
         </div>
@@ -323,13 +323,13 @@ Anchors present:
         <h3>Baseline vs Current Behavior</h3>
         <div class="grid cols-2">
           <div class="field">
-            <label id="labelHealthy" for="healthy">For this object, what does ‘healthy/normal’ behavior look like?</label>
-            <small>What was the expected behavior?</small>
+            <label id="labelHealthy" for="healthy">What normally should this object do, and what baseline establishes that expectation?</label>
+            <small>Which expected behavior, measure, or prior condition provides the normal baseline?</small>
             <textarea id="healthy" placeholder=""></textarea>
           </div>
           <div class="field">
-            <label id="labelNow" for="now">What is the current (actual) behavior of this object?</label>
-            <small>What have you measured or verified against the baseline (using the same metrics as above), and what symptoms are you observing now?</small>
+            <label id="labelNow" for="now">What is this object doing now, and how does that actual behavior differ from the baseline?</label>
+            <small>Which current observations or measurements show how actual behavior differs from that baseline?</small>
             <textarea id="now" placeholder=""></textarea>
           </div>
         </div>
@@ -347,21 +347,21 @@ Anchors present:
       <h3>Impact</h3>
       <div class="grid cols-3 gap-24">
         <div class="field">
-          <h3 id="impactNowHeading">Current Impact</h3>
-          <label class="visually-hidden" for="impactNow">Current Impact</label>
-          <small>Who or what is currently affected? Quantify: users/tenants/regions, transactions failing, SLI/SLO deltas (avail %, p95/p99, error %), data at risk (loss/corruption/exposure), workarounds.</small>
+          <h3 id="impactNowHeading">What is the current impact?</h3>
+          <label class="visually-hidden" for="impactNow">What is the current impact?</label>
+          <small>Who or what is affected now, and how large or severe is the impact?</small>
           <textarea id="impactNow" aria-labelledby="impactNowHeading" placeholder=""></textarea>
         </div>
         <div class="field">
-          <h3 id="impactFutureHeading">Future Impact</h3>
-          <label class="visually-hidden" for="impactFuture">Future Impact</label>
-          <small>If unresolved, what is the likely future impact? Blast radius growth, SLO/SLA breach, revenue/penalties, compliance, backlog/consumer lag, churn, on-call fatigue.</small>
+          <h3 id="impactFutureHeading">What future impact is likely if the issue remains unresolved?</h3>
+          <label class="visually-hidden" for="impactFuture">What future impact is likely if the issue remains unresolved?</label>
+          <small>What downstream effect is likely if the deviation continues unresolved?</small>
           <textarea id="impactFuture" aria-labelledby="impactFutureHeading" placeholder=""></textarea>
         </div>
         <div class="field">
-          <h3 id="impactTimeHeading">Timeframe</h3>
-          <label class="visually-hidden" for="impactTime">Timeframe</label>
-          <small>When will the Future Impact become Current Impact? (Best Estimate). What deadlines/SLAs do we need to be aware of?</small>
+          <h3 id="impactTimeHeading">By what specific deadline or timeframe does resolution become difficult, expensive, impossible, or meaningless?</h3>
+          <label class="visually-hidden" for="impactTime">By what specific deadline or timeframe does resolution become difficult, expensive, impossible, or meaningless?</label>
+          <small>When does a deadline, dependency, or decision point make resolution difficult, expensive, impossible, or meaningless?</small>
           <textarea id="impactTime" aria-labelledby="impactTimeHeading" placeholder=""></textarea>
         </div>
       </div>

--- a/src/intakeModes.js
+++ b/src/intakeModes.js
@@ -154,44 +154,44 @@ export const INTAKE_MODE_SECTION_VISIBILITY = deepFreeze({
  */
 export const INTAKE_MODE_CAPTION_OVERRIDES = deepFreeze({
   [INTAKE_MODE_IDS.GENERAL]: {
-    oneLine: 'One-line summary',
-    proof: 'Evidence',
-    objectPrefill: 'Object or process',
-    healthy: 'Expected state',
-    now: 'Current state',
-    impactNow: 'Current impact',
-    impactFuture: 'Potential impact',
-    impactTime: 'Timing context'
+    oneLine: 'What issue is affecting the service or capability, and how is it degraded?',
+    proof: 'What observable or measurable evidence confirms a deviation from normal?',
+    objectPrefill: 'Which specific object is affected, and what identifies it?',
+    healthy: 'What normally should this object do, and what baseline establishes that expectation?',
+    now: 'What is this object doing now, and how does that actual behavior differ from the baseline?',
+    impactNow: 'What is the current impact?',
+    impactFuture: 'What future impact is likely if the issue remains unresolved?',
+    impactTime: 'By what specific deadline or timeframe does resolution become difficult, expensive, impossible, or meaningless?'
   },
   [INTAKE_MODE_IDS.IT]: {
-    oneLine: 'Technology operations summary',
-    proof: 'Operational evidence',
-    objectPrefill: 'Affected service or component',
-    healthy: 'Expected service behavior',
-    now: 'Current service behavior',
-    impactNow: 'Current user or system impact',
-    impactFuture: 'Potential operational risk',
-    impactTime: 'Detection and timing context'
+    oneLine: 'What stated issue is degrading which service or capability?',
+    proof: 'What observable or measurable evidence confirms the technical deviation?',
+    objectPrefill: 'Which specific IT object is affected, including its OS, platform, version, and configuration?',
+    healthy: 'What service behavior is expected, and what technical baseline or SLO defines normal?',
+    now: 'What is the actual service behavior now, and how does it differ from that baseline?',
+    impactNow: 'What is the current user or system impact?',
+    impactFuture: 'What future operational impact is likely if the issue remains unresolved?',
+    impactTime: 'By what specific deadline or timeframe does resolution become difficult, expensive, impossible, or meaningless?'
   },
   [INTAKE_MODE_IDS.PHARMA]: {
-    oneLine: 'Quality event summary',
-    proof: 'Deviation evidence',
-    objectPrefill: 'Product, process, or batch',
-    healthy: 'Expected validated state',
-    now: 'Observed deviation',
-    impactNow: 'Current quality or patient impact',
-    impactFuture: 'Potential compliance or release impact',
-    impactTime: 'Discovery and process timing'
+    oneLine: 'What quality event is affecting which product, process, or batch?',
+    proof: 'What observable or measurable evidence confirms the deviation?',
+    objectPrefill: 'Which specific product, process, batch, material, or equipment object is affected?',
+    healthy: 'What validated or approved state is expected, and what baseline defines it?',
+    now: 'What actual condition is observed now, and how does it differ from the expected state?',
+    impactNow: 'What is the current quality, release, safety, or patient impact?',
+    impactFuture: 'What future compliance, stability, supply, or patient impact is likely if unresolved?',
+    impactTime: 'By what process deadline or timeframe does resolution become difficult, expensive, impossible, or meaningless?'
   },
   [INTAKE_MODE_IDS.MAJOR_INCIDENT]: {
-    oneLine: 'Major incident summary',
-    proof: 'Incident proof',
-    objectPrefill: 'Impacted object or service',
-    healthy: 'Healthy baseline',
-    now: 'Current deviation',
-    impactNow: 'Current incident impact',
-    impactFuture: 'Projected incident impact',
-    impactTime: 'Incident timeline context'
+    oneLine: 'What major incident is degrading which customer-facing service or capability?',
+    proof: 'What observable or measurable evidence confirms the incident deviation?',
+    objectPrefill: 'Which specific service, platform, region, or workflow object is affected?',
+    healthy: 'What known-good behavior is expected, and what baseline should responders use?',
+    now: 'What actual behavior are responders seeing now, and how does it differ from the baseline?',
+    impactNow: 'What is the current incident impact and blast radius?',
+    impactFuture: 'What future incident impact is likely if containment does not improve?',
+    impactTime: 'By what incident deadline or timeframe does resolution become difficult, expensive, impossible, or meaningless?'
   }
 });
 
@@ -205,44 +205,44 @@ export const INTAKE_MODE_CAPTION_OVERRIDES = deepFreeze({
  */
 export const INTAKE_MODE_HELPER_OVERRIDES = deepFreeze({
   [INTAKE_MODE_IDS.GENERAL]: {
-    oneLine: 'Summarize the issue in one calm, specific sentence.',
-    proof: 'List the evidence that confirms the issue is real.',
-    objectPrefill: 'Name the object, workflow, or outcome being investigated.',
-    healthy: 'Describe what normal looks like before comparing the deviation.',
-    now: 'Describe what is happening right now.',
-    impactNow: 'Capture who or what is affected today.',
-    impactFuture: 'Note credible downstream risks if nothing changes.',
-    impactTime: 'Record when the issue started or was first noticed.'
+    oneLine: 'Which issue, affected service or capability, and degradation belong in one concise statement?',
+    proof: 'Which alerts, observations, measurements, reports, or reproducible results demonstrate the deviation?',
+    objectPrefill: 'Which service, process, tool, machine, model, or configuration details distinguish the affected object?',
+    healthy: 'Which expected behavior, measure, or prior condition provides the normal baseline?',
+    now: 'Which current observations or measurements show how actual behavior differs from that baseline?',
+    impactNow: 'Who or what is affected now, and how large or severe is the impact?',
+    impactFuture: 'What downstream effect is likely if the deviation continues unresolved?',
+    impactTime: 'When does a deadline, dependency, or decision point make resolution difficult, expensive, impossible, or meaningless?'
   },
   [INTAKE_MODE_IDS.IT]: {
-    oneLine: 'Summarize the technology operations issue, scope, and symptom briefly.',
-    proof: 'Capture alerts, customer reports, logs, metrics, or reproduction evidence.',
-    objectPrefill: 'Use the service, application, dependency, or infrastructure name.',
-    healthy: 'Document the expected technical behavior or SLO baseline.',
-    now: 'Capture the current behavior, alerts, or user-reported symptom.',
-    impactNow: 'Quantify affected users, transactions, regions, or dependencies.',
-    impactFuture: 'Call out likely downstream operational risks, deadlines, or dependencies.',
-    impactTime: 'Include detection time, suspected start, and recent change windows.'
+    oneLine: 'Which stated issue, degraded service or capability, scope, and symptom belong in one concise statement?',
+    proof: 'Which alerts, logs, metrics, customer reports, or reproduction results measure the technical deviation?',
+    objectPrefill: 'Which service, application, dependency, host, OS, platform, version, and configuration identify the affected IT object?',
+    healthy: 'Which expected technical behavior, SLO, metric, or known-good configuration provides the baseline?',
+    now: 'Which current behavior, alerts, metrics, or user symptoms show the difference from that baseline?',
+    impactNow: 'Which users, transactions, regions, systems, or dependencies are affected now, and by how much?',
+    impactFuture: 'Which operational risk, deadline, or dependent service will be affected if the issue remains unresolved?',
+    impactTime: 'When do an SLA, release, dependency, or other deadline make resolution difficult, expensive, impossible, or meaningless?'
   },
   [INTAKE_MODE_IDS.PHARMA]: {
-    oneLine: 'Summarize the deviation with product/process context and batch scope.',
-    proof: 'Capture inspection results, assay data, exceptions, complaints, or verified observations.',
-    objectPrefill: 'Identify the material, equipment, process step, study, or batch.',
-    healthy: 'Reference the approved specification, validated state, or expected control.',
-    now: 'Describe the observed out-of-expectation condition without changing KT prompts.',
-    impactNow: 'Capture current quality, safety, release, or patient implications.',
-    impactFuture: 'Note possible compliance, stability, supply, or investigation risks.',
-    impactTime: 'Record discovery timing, processing stage, and relevant hold points.'
+    oneLine: 'Which deviation, product or process context, and batch scope belong in one concise statement?',
+    proof: 'Which inspection results, assay data, exceptions, complaints, or verified observations demonstrate the deviation?',
+    objectPrefill: 'Which material, equipment, process step, study, product, or batch identifiers distinguish the affected object?',
+    healthy: 'Which approved specification, validated state, or control provides the expected baseline?',
+    now: 'Which observed out-of-expectation condition shows the difference from the approved baseline?',
+    impactNow: 'Which current quality, safety, release, or patient implications are present now?',
+    impactFuture: 'Which compliance, stability, supply, or investigation risk is likely if the deviation remains unresolved?',
+    impactTime: 'When do hold points, release dates, or process deadlines make resolution difficult, expensive, impossible, or meaningless?'
   },
   [INTAKE_MODE_IDS.MAJOR_INCIDENT]: {
-    oneLine: 'Summarize the major incident so responders can align quickly.',
-    proof: 'Capture the alerts, metrics, reports, screenshots, or logs proving abnormal behavior.',
-    objectPrefill: 'Name the customer-facing service, platform, region, or workflow.',
-    healthy: 'Describe the known-good baseline responders should compare against.',
-    now: 'Describe the active deviation responders are seeing now.',
-    impactNow: 'Capture current blast radius, severity, and customer impact.',
-    impactFuture: 'Capture near-term escalation risk if containment does not improve.',
-    impactTime: 'Record start, detection, bridge, and update-cadence timing.'
+    oneLine: 'Which major incident, degraded customer-facing service or capability, and scope should responders align on?',
+    proof: 'Which alerts, metrics, reports, screenshots, or logs demonstrate the incident deviation?',
+    objectPrefill: 'Which customer-facing service, platform, region, workflow, or configuration details distinguish the affected object?',
+    healthy: 'Which known-good behavior, metric, or service baseline should responders use for comparison?',
+    now: 'Which active behavior, measurements, or customer symptoms show the difference from that baseline?',
+    impactNow: 'Which customers, services, regions, or business functions are affected now, and what is the blast radius?',
+    impactFuture: 'Which near-term escalation or customer impact is likely if containment does not improve?',
+    impactTime: 'When do recovery commitments, updates, or business deadlines make resolution difficult, expensive, impossible, or meaningless?'
   }
 });
 

--- a/tests/intakeModeController.unit.test.mjs
+++ b/tests/intakeModeController.unit.test.mjs
@@ -99,8 +99,8 @@ test('selector changes apply mode visibility and emit a save callback', () => {
   assert.equal(document.getElementById('detectionSource').hidden, true);
   assert.equal(document.getElementById('evidenceCollected').hidden, true);
   assert.equal(document.getElementById('proofField').hidden, true);
-  assert.equal(document.querySelector('label[for="proof"]').textContent, 'Deviation evidence');
-  assert.equal(document.getElementById('impactNowHeading').textContent, 'Current quality or patient impact');
+  assert.equal(document.querySelector('label[for="proof"]').textContent, 'What observable or measurable evidence confirms the deviation?');
+  assert.equal(document.getElementById('impactNowHeading').textContent, 'What is the current quality, release, safety, or patient impact?');
 
   applyIntakeMode(INTAKE_MODE_IDS.MAJOR_INCIDENT, { silent: true });
   assert.equal(document.getElementById('commsDrawer').hidden, false);
@@ -109,6 +109,26 @@ test('selector changes apply mode visibility and emit a save callback', () => {
   assert.equal(document.getElementById('evidenceCollected').hidden, false);
   assert.equal(document.getElementById('proofField').hidden, false);
   assert.equal(document.getElementById('containment').hidden, false);
+});
+
+
+test('mode changes render representative question-led captions in the mounted DOM', () => {
+  const document = mountModeDom();
+  initIntakeModeController();
+
+  const expected = {
+    [INTAKE_MODE_IDS.GENERAL]: ['What issue is affecting the service or capability, and how is it degraded?', 'What is the current impact?'],
+    [INTAKE_MODE_IDS.IT]: ['Which specific IT object is affected, including its OS, platform, version, and configuration?', 'What is the current user or system impact?'],
+    [INTAKE_MODE_IDS.PHARMA]: ['What quality event is affecting which product, process, or batch?', 'What is the current quality, release, safety, or patient impact?'],
+    [INTAKE_MODE_IDS.MAJOR_INCIDENT]: ['What major incident is degrading which customer-facing service or capability?', 'What is the current incident impact and blast radius?']
+  };
+
+  Object.entries(expected).forEach(([modeId, [labelText, headingText]]) => {
+    applyIntakeMode(modeId, { silent: true });
+    const label = [...document.querySelectorAll('label')].find((element) => element.textContent === labelText);
+    assert.ok(label, `${modeId} should render its representative question label`);
+    assert.equal(document.getElementById('impactNowHeading').textContent, headingText);
+  });
 });
 
 test('saved General, IT, Pharma, and Major Incident states restore the active mode', () => {

--- a/tests/intakeModes.unit.test.mjs
+++ b/tests/intakeModes.unit.test.mjs
@@ -67,6 +67,45 @@ test('caption and helper override maps preserve stable field IDs for every mode'
   });
 });
 
+
+test('every mode provides question-led prompts for each controlled field', () => {
+  const expectedCopy = {
+    [INTAKE_MODE_IDS.GENERAL]: {
+      oneLine: /service or capability.*degraded/i,
+      objectPrefill: /specific object.*identifies it/i,
+      impactTime: /difficult, expensive, impossible, or meaningless/i
+    },
+    [INTAKE_MODE_IDS.IT]: {
+      oneLine: /stated issue.*service or capability/i,
+      objectPrefill: /OS, platform, version, and configuration/i,
+      impactTime: /difficult, expensive, impossible, or meaningless/i
+    },
+    [INTAKE_MODE_IDS.PHARMA]: {
+      oneLine: /quality event.*product, process, or batch/i,
+      proof: /observable or measurable evidence/i,
+      impactTime: /difficult, expensive, impossible, or meaningless/i
+    },
+    [INTAKE_MODE_IDS.MAJOR_INCIDENT]: {
+      oneLine: /major incident.*service or capability/i,
+      now: /differ from the baseline/i,
+      impactTime: /difficult, expensive, impossible, or meaningless/i
+    }
+  };
+
+  Object.values(INTAKE_MODE_IDS).forEach((modeId) => {
+    REQUIRED_FIELD_IDS.forEach((fieldId) => {
+      const { label, helper } = INTAKE_MODE_FIELD_CAPTIONS[modeId][fieldId];
+      assert.match(label, /\?$/, `${modeId}.${fieldId} label should be a question`);
+      assert.match(helper, /\?$/, `${modeId}.${fieldId} helper should be a question`);
+      assert.equal(label, INTAKE_MODE_CAPTION_OVERRIDES[modeId][fieldId]);
+      assert.equal(helper, INTAKE_MODE_HELPER_OVERRIDES[modeId][fieldId]);
+    });
+    Object.entries(expectedCopy[modeId]).forEach(([fieldId, pattern]) => {
+      assert.match(INTAKE_MODE_FIELD_CAPTIONS[modeId][fieldId].label, pattern);
+    });
+  });
+});
+
 test('IT and Major Incident use distinct operations and incident copy maps', () => {
   assert.notDeepEqual(
     INTAKE_MODE_CAPTION_OVERRIDES[INTAKE_MODE_IDS.IT],
@@ -82,7 +121,7 @@ test('IT and Major Incident use distinct operations and incident copy maps', () 
     ...Object.values(INTAKE_MODE_HELPER_OVERRIDES[INTAKE_MODE_IDS.IT])
   ].join(' ');
   assert.doesNotMatch(itCopy, /\b(bridge|comms|communications|handover)\b/i);
-  assert.match(itCopy, /technology operations/i);
+  assert.match(itCopy, /technical deviation/i);
 
   const majorIncidentCopy = [
     ...Object.values(INTAKE_MODE_CAPTION_OVERRIDES[INTAKE_MODE_IDS.MAJOR_INCIDENT]),
@@ -90,7 +129,7 @@ test('IT and Major Incident use distinct operations and incident copy maps', () 
   ].join(' ');
   assert.match(majorIncidentCopy, /major incident/i);
   assert.match(majorIncidentCopy, /responders/i);
-  assert.match(majorIncidentCopy, /bridge/i);
+  assert.match(majorIncidentCopy, /blast radius/i);
 });
 
 test('IT keeps the same minimal visible sections as General and Pharma', () => {

--- a/tests/preface.feature.test.mjs
+++ b/tests/preface.feature.test.mjs
@@ -162,8 +162,8 @@ test('preface: mirrors KT fields, normalises containment, and updates titles', a
   objectPrefill.dispatchEvent(new window.Event('input', { bubbles: true }));
 
   assert.equal(objectISField.value, 'Edge Router service');
-  assert.equal(document.getElementById('labelNow').textContent, 'Current state');
-  assert.equal(document.getElementById('labelHealthy').textContent, 'Expected state');
+  assert.equal(document.getElementById('labelNow').textContent, 'What is this object doing now, and how does that actual behavior differ from the baseline?');
+  assert.equal(document.getElementById('labelHealthy').textContent, 'What normally should this object do, and what baseline establishes that expectation?');
   assert.equal(document.getElementById('docTitle').textContent, 'KT Intake');
   assert.equal(document.getElementById('docSubtitle').textContent, '');
   assert.equal(document.title, 'KT Intake');
@@ -183,15 +183,15 @@ test('preface: mirrors KT fields, normalises containment, and updates titles', a
   assert.equal(document.getElementById('docTitle').textContent, 'Edge Router service — Traffic drop for users');
   assert.equal(document.getElementById('docSubtitle').textContent, '');
   assert.equal(document.title, 'Edge Router service — Traffic drop for users · KT Intake');
-  assert.equal(document.getElementById('labelHealthy').textContent, 'Expected state');
+  assert.equal(document.getElementById('labelHealthy').textContent, 'What normally should this object do, and what baseline establishes that expectation?');
 
   deviationISField.value = '';
   nowField.value = '';
   nowField.dispatchEvent(new window.Event('input', { bubbles: true }));
   assert.equal(document.getElementById('docTitle').textContent, 'KT Intake');
   assert.equal(document.getElementById('docSubtitle').textContent, '');
-  assert.equal(document.getElementById('labelNow').textContent, 'Current state');
-  assert.equal(document.getElementById('labelHealthy').textContent, 'Expected state');
+  assert.equal(document.getElementById('labelNow').textContent, 'What is this object doing now, and how does that actual behavior differ from the baseline?');
+  assert.equal(document.getElementById('labelHealthy').textContent, 'What normally should this object do, and what baseline establishes that expectation?');
   assert.equal(document.title, 'KT Intake');
 
   objectISField.value = '';
@@ -199,8 +199,8 @@ test('preface: mirrors KT fields, normalises containment, and updates titles', a
   objectPrefill.dispatchEvent(new window.Event('input', { bubbles: true }));
   assert.equal(document.getElementById('docTitle').textContent, 'KT Intake');
   assert.equal(document.getElementById('docSubtitle').textContent, '');
-  assert.equal(document.getElementById('labelNow').textContent, 'Current state');
-  assert.equal(document.getElementById('labelHealthy').textContent, 'Expected state');
+  assert.equal(document.getElementById('labelNow').textContent, 'What is this object doing now, and how does that actual behavior differ from the baseline?');
+  assert.equal(document.getElementById('labelHealthy').textContent, 'What normally should this object do, and what baseline establishes that expectation?');
 
   applyPrefaceState({
     ops: { containStatus: 'mitigation' }

--- a/tests/summary.feature.test.mjs
+++ b/tests/summary.feature.test.mjs
@@ -380,15 +380,15 @@ test('summary: non-major modes use mode labels and exclude major-incident-only s
   const text = buildSummaryText(state);
 
   assert.ok(text.includes('— Technology Operations Summary —'));
-  assert.ok(text.includes('• Technology operations summary: Checkout payments are failing'));
-  assert.ok(text.includes('• Affected service or component: Payments API'));
+  assert.ok(text.includes('• What stated issue is degrading which service or capability?: Checkout payments are failing'));
+  assert.ok(text.includes('• Which specific IT object is affected, including its OS, platform, version, and configuration?: Payments API'));
   assert.ok(!text.includes('Operational evidence'));
   assert.ok(!text.includes('Synthetic monitor and logs confirm errors'));
   assert.ok(!text.includes('Detection Source'));
   assert.ok(!text.includes('Evidence Collected'));
-  assert.ok(text.includes('Current user or system impact: Customers cannot complete checkout'));
-  assert.ok(text.includes('Potential operational risk: Backlog may trigger order cancellations'));
-  assert.ok(text.includes('Detection and timing context: Detected at 12:45 UTC'));
+  assert.ok(text.includes('What is the current user or system impact?: Customers cannot complete checkout'));
+  assert.ok(text.includes('What future operational impact is likely if the issue remains unresolved?: Backlog may trigger order cancellations'));
+  assert.ok(text.includes('By what specific deadline or timeframe does resolution become difficult, expensive, impossible, or meaningless?: Detected at 12:45 UTC'));
   assert.ok(text.includes('— Problem Analysis —'));
   assert.ok(text.includes('— Possible Causes —'));
   assert.ok(text.includes('Likely Cause:'));


### PR DESCRIPTION
### Motivation
- Replace imperative labels/helpers with question-led copy so operators capture the stated issue, affected object (with IT/OE details where relevant), verifiable evidence, baseline vs actual behavior, current & future impact, and an actionable deadline/timeframe.
- Keep a single derived source (`INTAKE_MODE_FIELD_CAPTIONS`) so the UI layer continues to update visible labels, helpers, headings, and ARIA labels without renaming DOM IDs or storage keys.

### Description
- Rewrote `INTAKE_MODE_CAPTION_OVERRIDES` and `INTAKE_MODE_HELPER_OVERRIDES` in `src/intakeModes.js` for `oneLine`, `proof`, `objectPrefill`, `healthy`, `now`, `impactNow`, `impactFuture`, and `impactTime` across General, IT, Pharma, and Major Incident modes to be question-led and cover the required details.
- Preserved `INTAKE_MODE_FIELD_CAPTIONS` as the single derived bundle used by `src/captionLayer.js` so runtime caption application is unchanged.
- Updated the no-JavaScript fallback text in `index.html` (labels, small helper text, impact headings and visually-hidden labels) while preserving all anchors, IDs, and ARIA attributes.
- Extended and adjusted tests to validate the new copy and rendering: `tests/intakeModes.unit.test.mjs`, `tests/intakeModeController.unit.test.mjs`, `tests/preface.feature.test.mjs`, and `tests/summary.feature.test.mjs` now assert question-led captions and representative DOM rendering.

### Testing
- Ran `npm test` (unit + feature suites) and the full test run passed; modified tests exercise both data maps and mounted DOM behavior.
- Ran `npm run lint` and `npm run verify:tests` (the latter passed using the working-tree fallback in this environment because no resolvable base branch was available).
- Ran `git diff --check` to ensure no trailing whitespace or obvious diff-check issues.
- All automated checks succeeded in this environment and the updated test suites confirm the new question-oriented copy is present and applied at render time.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a611c22f0208324b81e4b1771cff018)