### PR TITLE
Clarify General, IT, and Pharma intake prompts

### DIFF
--- a/src/intakeModes.js
+++ b/src/intakeModes.js
@@ -154,34 +154,34 @@ export const INTAKE_MODE_SECTION_VISIBILITY = deepFreeze({
  */
 export const INTAKE_MODE_CAPTION_OVERRIDES = deepFreeze({
   [INTAKE_MODE_IDS.GENERAL]: {
-    oneLine: 'What issue is affecting the service or capability, and how is it degraded?',
-    proof: 'What observable or measurable evidence confirms a deviation from normal?',
-    objectPrefill: 'Which specific object is affected, and what identifies it?',
-    healthy: 'What normally should this object do, and what baseline establishes that expectation?',
-    now: 'What is this object doing now, and how does that actual behavior differ from the baseline?',
+    oneLine: 'What problem is affecting the service or capability?',
+    proof: 'What evidence confirms the deviation?',
+    objectPrefill: 'Which object is affected?',
+    healthy: 'What should the object do normally?',
+    now: 'What is the object doing now?',
     impactNow: 'What is the current impact?',
-    impactFuture: 'What future impact is likely if the issue remains unresolved?',
-    impactTime: 'By what specific deadline or timeframe does resolution become difficult, expensive, impossible, or meaningless?'
+    impactFuture: 'What future impact is likely if unresolved?',
+    impactTime: 'When is a decision or resolution needed?'
   },
   [INTAKE_MODE_IDS.IT]: {
-    oneLine: 'What stated issue is degrading which service or capability?',
-    proof: 'What observable or measurable evidence confirms the technical deviation?',
-    objectPrefill: 'Which specific IT object is affected, including its OS, platform, version, and configuration?',
-    healthy: 'What service behavior is expected, and what technical baseline or SLO defines normal?',
-    now: 'What is the actual service behavior now, and how does it differ from that baseline?',
+    oneLine: 'What IT service or capability is degraded?',
+    proof: 'What evidence confirms the technical deviation?',
+    objectPrefill: 'Which IT object is affected?',
+    healthy: 'What service behavior is expected?',
+    now: 'What is the actual service behavior now?',
     impactNow: 'What is the current user or system impact?',
-    impactFuture: 'What future operational impact is likely if the issue remains unresolved?',
-    impactTime: 'By what specific deadline or timeframe does resolution become difficult, expensive, impossible, or meaningless?'
+    impactFuture: 'What future operational impact is likely if unresolved?',
+    impactTime: 'When is a decision or resolution needed?'
   },
   [INTAKE_MODE_IDS.PHARMA]: {
-    oneLine: 'What quality event is affecting which product, process, or batch?',
-    proof: 'What observable or measurable evidence confirms the deviation?',
-    objectPrefill: 'Which specific product, process, batch, material, or equipment object is affected?',
-    healthy: 'What validated or approved state is expected, and what baseline defines it?',
-    now: 'What actual condition is observed now, and how does it differ from the expected state?',
+    oneLine: 'What quality event is affecting the product, process, or batch?',
+    proof: 'What evidence confirms the quality deviation?',
+    objectPrefill: 'Which product, process, batch, material, or equipment is affected?',
+    healthy: 'What validated or approved state is expected?',
+    now: 'What condition is observed now?',
     impactNow: 'What is the current quality, release, safety, or patient impact?',
     impactFuture: 'What future compliance, stability, supply, or patient impact is likely if unresolved?',
-    impactTime: 'By what process deadline or timeframe does resolution become difficult, expensive, impossible, or meaningless?'
+    impactTime: 'When is a quality decision or resolution needed?'
   },
   [INTAKE_MODE_IDS.MAJOR_INCIDENT]: {
     oneLine: 'What major incident is degrading which customer-facing service or capability?',
@@ -205,34 +205,34 @@ export const INTAKE_MODE_CAPTION_OVERRIDES = deepFreeze({
  */
 export const INTAKE_MODE_HELPER_OVERRIDES = deepFreeze({
   [INTAKE_MODE_IDS.GENERAL]: {
-    oneLine: 'Which issue, affected service or capability, and degradation belong in one concise statement?',
-    proof: 'Which alerts, observations, measurements, reports, or reproducible results demonstrate the deviation?',
-    objectPrefill: 'Which service, process, tool, machine, model, or configuration details distinguish the affected object?',
-    healthy: 'Which expected behavior, measure, or prior condition provides the normal baseline?',
-    now: 'Which current observations or measurements show how actual behavior differs from that baseline?',
-    impactNow: 'Who or what is affected now, and how large or severe is the impact?',
-    impactFuture: 'What downstream effect is likely if the deviation continues unresolved?',
-    impactTime: 'When does a deadline, dependency, or decision point make resolution difficult, expensive, impossible, or meaningless?'
+    oneLine: 'State the affected service or capability and the observed degradation.',
+    proof: 'Include alerts, observations, measurements, reports, or reproducible results.',
+    objectPrefill: 'Provide the service, process, tool, machine, model, or configuration identifier.',
+    healthy: 'Give the expected behavior, measure, or prior normal condition.',
+    now: 'Record current observations or measurements and the difference from normal.',
+    impactNow: 'Identify who or what is affected and quantify the current scope or severity.',
+    impactFuture: 'Describe the likely downstream effect if the deviation continues.',
+    impactTime: 'Include the relevant deadline, dependency, or decision point.'
   },
   [INTAKE_MODE_IDS.IT]: {
-    oneLine: 'Which stated issue, degraded service or capability, scope, and symptom belong in one concise statement?',
-    proof: 'Which alerts, logs, metrics, customer reports, or reproduction results measure the technical deviation?',
-    objectPrefill: 'Which service, application, dependency, host, OS, platform, version, and configuration identify the affected IT object?',
-    healthy: 'Which expected technical behavior, SLO, metric, or known-good configuration provides the baseline?',
-    now: 'Which current behavior, alerts, metrics, or user symptoms show the difference from that baseline?',
-    impactNow: 'Which users, transactions, regions, systems, or dependencies are affected now, and by how much?',
-    impactFuture: 'Which operational risk, deadline, or dependent service will be affected if the issue remains unresolved?',
-    impactTime: 'When do an SLA, release, dependency, or other deadline make resolution difficult, expensive, impossible, or meaningless?'
+    oneLine: 'State the degraded service or capability, symptom, and affected scope.',
+    proof: 'Include alerts, logs, metrics, customer reports, or reproduction results.',
+    objectPrefill: 'Provide the service, application, dependency, host, OS, platform, version, or configuration identifier.',
+    healthy: 'Give the expected behavior, SLO, metric, or known-good configuration.',
+    now: 'Record current behavior, alerts, metrics, or user symptoms against the baseline.',
+    impactNow: 'Identify affected users, transactions, regions, systems, or dependencies and quantify the scope.',
+    impactFuture: 'Describe the operational risk, deadline, or dependent service at risk.',
+    impactTime: 'Include the applicable SLA, release, dependency, or other deadline.'
   },
   [INTAKE_MODE_IDS.PHARMA]: {
-    oneLine: 'Which deviation, product or process context, and batch scope belong in one concise statement?',
-    proof: 'Which inspection results, assay data, exceptions, complaints, or verified observations demonstrate the deviation?',
-    objectPrefill: 'Which material, equipment, process step, study, product, or batch identifiers distinguish the affected object?',
-    healthy: 'Which approved specification, validated state, or control provides the expected baseline?',
-    now: 'Which observed out-of-expectation condition shows the difference from the approved baseline?',
-    impactNow: 'Which current quality, safety, release, or patient implications are present now?',
-    impactFuture: 'Which compliance, stability, supply, or investigation risk is likely if the deviation remains unresolved?',
-    impactTime: 'When do hold points, release dates, or process deadlines make resolution difficult, expensive, impossible, or meaningless?'
+    oneLine: 'State the deviation, product or process context, and batch scope.',
+    proof: 'Include inspection results, assay data, exceptions, complaints, or verified observations.',
+    objectPrefill: 'Provide the material, equipment, process step, study, product, or batch identifier.',
+    healthy: 'Give the approved specification, validated state, or control.',
+    now: 'Record the observed condition and its difference from the approved baseline.',
+    impactNow: 'Identify current quality, safety, release, or patient implications.',
+    impactFuture: 'Describe the likely compliance, stability, supply, or investigation risk.',
+    impactTime: 'Include hold points, release dates, or process deadlines.'
   },
   [INTAKE_MODE_IDS.MAJOR_INCIDENT]: {
     oneLine: 'Which major incident, degraded customer-facing service or capability, and scope should responders align on?',

--- a/tests/intakeModeController.unit.test.mjs
+++ b/tests/intakeModeController.unit.test.mjs
@@ -99,7 +99,7 @@ test('selector changes apply mode visibility and emit a save callback', () => {
   assert.equal(document.getElementById('detectionSource').hidden, true);
   assert.equal(document.getElementById('evidenceCollected').hidden, true);
   assert.equal(document.getElementById('proofField').hidden, true);
-  assert.equal(document.querySelector('label[for="proof"]').textContent, 'What observable or measurable evidence confirms the deviation?');
+  assert.equal(document.querySelector('label[for="proof"]').textContent, 'What evidence confirms the quality deviation?');
   assert.equal(document.getElementById('impactNowHeading').textContent, 'What is the current quality, release, safety, or patient impact?');
 
   applyIntakeMode(INTAKE_MODE_IDS.MAJOR_INCIDENT, { silent: true });
@@ -117,9 +117,9 @@ test('mode changes render representative question-led captions in the mounted DO
   initIntakeModeController();
 
   const expected = {
-    [INTAKE_MODE_IDS.GENERAL]: ['What issue is affecting the service or capability, and how is it degraded?', 'What is the current impact?'],
-    [INTAKE_MODE_IDS.IT]: ['Which specific IT object is affected, including its OS, platform, version, and configuration?', 'What is the current user or system impact?'],
-    [INTAKE_MODE_IDS.PHARMA]: ['What quality event is affecting which product, process, or batch?', 'What is the current quality, release, safety, or patient impact?'],
+    [INTAKE_MODE_IDS.GENERAL]: ['What problem is affecting the service or capability?', 'What is the current impact?'],
+    [INTAKE_MODE_IDS.IT]: ['Which IT object is affected?', 'What is the current user or system impact?'],
+    [INTAKE_MODE_IDS.PHARMA]: ['What quality event is affecting the product, process, or batch?', 'What is the current quality, release, safety, or patient impact?'],
     [INTAKE_MODE_IDS.MAJOR_INCIDENT]: ['What major incident is degrading which customer-facing service or capability?', 'What is the current incident impact and blast radius?']
   };
 
@@ -172,4 +172,3 @@ test('missing and invalid restored modes resolve to General even after another m
   assert.equal(getActiveIntakeMode(), INTAKE_MODE_IDS.GENERAL);
   assert.equal(document.getElementById('intakeModeSelect').value, INTAKE_MODE_IDS.GENERAL);
 });
-

--- a/tests/intakeModes.unit.test.mjs
+++ b/tests/intakeModes.unit.test.mjs
@@ -68,22 +68,22 @@ test('caption and helper override maps preserve stable field IDs for every mode'
 });
 
 
-test('every mode provides question-led prompts for each controlled field', () => {
+test('controlled fields use single-question labels and mode-appropriate helper guidance', () => {
   const expectedCopy = {
     [INTAKE_MODE_IDS.GENERAL]: {
-      oneLine: /service or capability.*degraded/i,
-      objectPrefill: /specific object.*identifies it/i,
-      impactTime: /difficult, expensive, impossible, or meaningless/i
+      oneLine: /problem.*service or capability/i,
+      objectPrefill: /which object is affected/i,
+      impactTime: /decision or resolution needed/i
     },
     [INTAKE_MODE_IDS.IT]: {
-      oneLine: /stated issue.*service or capability/i,
-      objectPrefill: /OS, platform, version, and configuration/i,
-      impactTime: /difficult, expensive, impossible, or meaningless/i
+      oneLine: /IT service or capability.*degraded/i,
+      objectPrefill: /which IT object is affected/i,
+      impactTime: /decision or resolution needed/i
     },
     [INTAKE_MODE_IDS.PHARMA]: {
       oneLine: /quality event.*product, process, or batch/i,
-      proof: /observable or measurable evidence/i,
-      impactTime: /difficult, expensive, impossible, or meaningless/i
+      proof: /evidence confirms the quality deviation/i,
+      impactTime: /quality decision or resolution needed/i
     },
     [INTAKE_MODE_IDS.MAJOR_INCIDENT]: {
       oneLine: /major incident.*service or capability/i,
@@ -96,13 +96,30 @@ test('every mode provides question-led prompts for each controlled field', () =>
     REQUIRED_FIELD_IDS.forEach((fieldId) => {
       const { label, helper } = INTAKE_MODE_FIELD_CAPTIONS[modeId][fieldId];
       assert.match(label, /\?$/, `${modeId}.${fieldId} label should be a question`);
-      assert.match(helper, /\?$/, `${modeId}.${fieldId} helper should be a question`);
+      if (modeId === INTAKE_MODE_IDS.MAJOR_INCIDENT) {
+        assert.match(helper, /\?$/, `${modeId}.${fieldId} helper should be a question`);
+      } else {
+        assert.doesNotMatch(helper, /\?$/, `${modeId}.${fieldId} helper should be concise guidance, not a question`);
+      }
       assert.equal(label, INTAKE_MODE_CAPTION_OVERRIDES[modeId][fieldId]);
       assert.equal(helper, INTAKE_MODE_HELPER_OVERRIDES[modeId][fieldId]);
     });
     Object.entries(expectedCopy[modeId]).forEach(([fieldId, pattern]) => {
       assert.match(INTAKE_MODE_FIELD_CAPTIONS[modeId][fieldId].label, pattern);
     });
+  });
+});
+
+test('General, IT, and Pharma helpers guide operators to concrete answer details', () => {
+  const guidancePatterns = {
+    [INTAKE_MODE_IDS.GENERAL]: /alerts.*measurements.*identifier.*scope.*deadline/is,
+    [INTAKE_MODE_IDS.IT]: /logs.*metrics.*identifier.*scope.*SLA/is,
+    [INTAKE_MODE_IDS.PHARMA]: /assay data.*identifier.*release.*hold points/is
+  };
+
+  Object.entries(guidancePatterns).forEach(([modeId, pattern]) => {
+    const helpers = Object.values(INTAKE_MODE_HELPER_OVERRIDES[modeId]).join(' ');
+    assert.match(helpers, pattern, `${modeId} helpers should identify concrete evidence and decision details`);
   });
 });
 

--- a/tests/preface.feature.test.mjs
+++ b/tests/preface.feature.test.mjs
@@ -162,8 +162,8 @@ test('preface: mirrors KT fields, normalises containment, and updates titles', a
   objectPrefill.dispatchEvent(new window.Event('input', { bubbles: true }));
 
   assert.equal(objectISField.value, 'Edge Router service');
-  assert.equal(document.getElementById('labelNow').textContent, 'What is this object doing now, and how does that actual behavior differ from the baseline?');
-  assert.equal(document.getElementById('labelHealthy').textContent, 'What normally should this object do, and what baseline establishes that expectation?');
+  assert.equal(document.getElementById('labelNow').textContent, 'What is the object doing now?');
+  assert.equal(document.getElementById('labelHealthy').textContent, 'What should the object do normally?');
   assert.equal(document.getElementById('docTitle').textContent, 'KT Intake');
   assert.equal(document.getElementById('docSubtitle').textContent, '');
   assert.equal(document.title, 'KT Intake');
@@ -183,15 +183,15 @@ test('preface: mirrors KT fields, normalises containment, and updates titles', a
   assert.equal(document.getElementById('docTitle').textContent, 'Edge Router service — Traffic drop for users');
   assert.equal(document.getElementById('docSubtitle').textContent, '');
   assert.equal(document.title, 'Edge Router service — Traffic drop for users · KT Intake');
-  assert.equal(document.getElementById('labelHealthy').textContent, 'What normally should this object do, and what baseline establishes that expectation?');
+  assert.equal(document.getElementById('labelHealthy').textContent, 'What should the object do normally?');
 
   deviationISField.value = '';
   nowField.value = '';
   nowField.dispatchEvent(new window.Event('input', { bubbles: true }));
   assert.equal(document.getElementById('docTitle').textContent, 'KT Intake');
   assert.equal(document.getElementById('docSubtitle').textContent, '');
-  assert.equal(document.getElementById('labelNow').textContent, 'What is this object doing now, and how does that actual behavior differ from the baseline?');
-  assert.equal(document.getElementById('labelHealthy').textContent, 'What normally should this object do, and what baseline establishes that expectation?');
+  assert.equal(document.getElementById('labelNow').textContent, 'What is the object doing now?');
+  assert.equal(document.getElementById('labelHealthy').textContent, 'What should the object do normally?');
   assert.equal(document.title, 'KT Intake');
 
   objectISField.value = '';
@@ -199,8 +199,8 @@ test('preface: mirrors KT fields, normalises containment, and updates titles', a
   objectPrefill.dispatchEvent(new window.Event('input', { bubbles: true }));
   assert.equal(document.getElementById('docTitle').textContent, 'KT Intake');
   assert.equal(document.getElementById('docSubtitle').textContent, '');
-  assert.equal(document.getElementById('labelNow').textContent, 'What is this object doing now, and how does that actual behavior differ from the baseline?');
-  assert.equal(document.getElementById('labelHealthy').textContent, 'What normally should this object do, and what baseline establishes that expectation?');
+  assert.equal(document.getElementById('labelNow').textContent, 'What is the object doing now?');
+  assert.equal(document.getElementById('labelHealthy').textContent, 'What should the object do normally?');
 
   applyPrefaceState({
     ops: { containStatus: 'mitigation' }

--- a/tests/summary.feature.test.mjs
+++ b/tests/summary.feature.test.mjs
@@ -380,15 +380,15 @@ test('summary: non-major modes use mode labels and exclude major-incident-only s
   const text = buildSummaryText(state);
 
   assert.ok(text.includes('— Technology Operations Summary —'));
-  assert.ok(text.includes('• What stated issue is degrading which service or capability?: Checkout payments are failing'));
-  assert.ok(text.includes('• Which specific IT object is affected, including its OS, platform, version, and configuration?: Payments API'));
+  assert.ok(text.includes('• What IT service or capability is degraded?: Checkout payments are failing'));
+  assert.ok(text.includes('• Which IT object is affected?: Payments API'));
   assert.ok(!text.includes('Operational evidence'));
   assert.ok(!text.includes('Synthetic monitor and logs confirm errors'));
   assert.ok(!text.includes('Detection Source'));
   assert.ok(!text.includes('Evidence Collected'));
   assert.ok(text.includes('What is the current user or system impact?: Customers cannot complete checkout'));
-  assert.ok(text.includes('What future operational impact is likely if the issue remains unresolved?: Backlog may trigger order cancellations'));
-  assert.ok(text.includes('By what specific deadline or timeframe does resolution become difficult, expensive, impossible, or meaningless?: Detected at 12:45 UTC'));
+  assert.ok(text.includes('What future operational impact is likely if unresolved?: Backlog may trigger order cancellations'));
+  assert.ok(text.includes('When is a decision or resolution needed?: Detected at 12:45 UTC'));
   assert.ok(text.includes('— Problem Analysis —'));
   assert.ok(text.includes('— Possible Causes —'));
   assert.ok(text.includes('Likely Cause:'));


### PR DESCRIPTION
### Motivation
- Make intake prompts for General, IT, and Pharma modes clearer and more actionable by replacing long or duplicate question phrasing with single, focused question labels and concise helper guidance.
- Preserve existing storage keys, field IDs, section visibility, and overall intent (problem statement, evidence, affected object, baseline vs actual, impacts, and timing) while improving operator guidance.

### Description
- Simplified the eight controlled field labels for `General`, `IT`, and `Pharma` in `src/intakeModes.js` so each label is a single clear question (fields: `oneLine`, `proof`, `objectPrefill`, `healthy`, `now`, `impactNow`, `impactFuture`, `impactTime`).
- Replaced near-duplicate helper questions for those modes with concise guidance that points to concrete answer details (examples: alerts/logs/assay data, identifiers, baselines/SLOs, scope/metrics, deadlines/decision points).
- Kept `Major Incident` copy unchanged and preserved all field IDs, storage keys, caption-layer behavior, and section visibility logic.
- Updated unit and feature tests to reflect the new caption/helper contract in `tests/intakeModes.unit.test.mjs`, `tests/intakeModeController.unit.test.mjs`, `tests/preface.feature.test.mjs`, and `tests/summary.feature.test.mjs`.

### Testing
- Ran the full test suite with `npm test` and all tests passed (`97 pass, 0 fail` in the final run). 
- Ran `npm run lint` with no reported errors and `npm run verify:tests` to ensure coverage changes are accounted for; both succeeded locally.
- Verified `git diff --check` produced no whitespace or diff errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a611f620f948324960edaf1771c7f11)