### PR TITLE
Clarify General intake prompts

### DIFF
--- a/src/intakeModes.js
+++ b/src/intakeModes.js
@@ -154,11 +154,11 @@ export const INTAKE_MODE_SECTION_VISIBILITY = deepFreeze({
  */
 export const INTAKE_MODE_CAPTION_OVERRIDES = deepFreeze({
   [INTAKE_MODE_IDS.GENERAL]: {
-    oneLine: 'What problem is affecting the service or capability?',
-    proof: 'What evidence confirms the deviation?',
-    objectPrefill: 'Which object is affected?',
-    healthy: 'What should the object do normally?',
-    now: 'What is the object doing now?',
+    oneLine: 'What is wrong, what affected item is involved, and how does it differ from expectation?',
+    proof: 'What evidence confirms the observed difference?',
+    objectPrefill: 'Which affected item or object should be examined?',
+    healthy: 'What condition or behavior is expected for the affected item?',
+    now: 'What condition or behavior is observed for the affected item now?',
     impactNow: 'What is the current impact?',
     impactFuture: 'What future impact is likely if unresolved?',
     impactTime: 'When is a decision or resolution needed?'
@@ -205,14 +205,14 @@ export const INTAKE_MODE_CAPTION_OVERRIDES = deepFreeze({
  */
 export const INTAKE_MODE_HELPER_OVERRIDES = deepFreeze({
   [INTAKE_MODE_IDS.GENERAL]: {
-    oneLine: 'State the affected service or capability and the observed degradation.',
-    proof: 'Include alerts, observations, measurements, reports, or reproducible results.',
-    objectPrefill: 'Provide the service, process, tool, machine, model, or configuration identifier.',
-    healthy: 'Give the expected behavior, measure, or prior normal condition.',
-    now: 'Record current observations or measurements and the difference from normal.',
-    impactNow: 'Identify who or what is affected and quantify the current scope or severity.',
-    impactFuture: 'Describe the likely downstream effect if the deviation continues.',
-    impactTime: 'Include the relevant deadline, dependency, or decision point.'
+    oneLine: 'For example, describe a product defect, delayed workflow, equipment fault, or unexpected service result.',
+    proof: 'For example, include observations, measurements, photos, reports, test results, or user feedback.',
+    objectPrefill: 'For example, name a product, process step, equipment item, workflow, document, or service.',
+    healthy: 'For example, note the approved specification, expected result, normal timing, or prior condition.',
+    now: 'For example, record the observed defect, result, measurement, timing, or condition.',
+    impactNow: 'For example, identify effects on people, output, cost, quality, safety, schedule, or availability.',
+    impactFuture: 'For example, note likely rework, delay, loss, risk, or wider effect if unresolved.',
+    impactTime: 'For example, state a decision date, delivery date, dependency, deadline, or point of no return.'
   },
   [INTAKE_MODE_IDS.IT]: {
     oneLine: 'State the degraded service or capability, symptom, and affected scope.',

--- a/tests/intakeModeController.unit.test.mjs
+++ b/tests/intakeModeController.unit.test.mjs
@@ -117,7 +117,7 @@ test('mode changes render representative question-led captions in the mounted DO
   initIntakeModeController();
 
   const expected = {
-    [INTAKE_MODE_IDS.GENERAL]: ['What problem is affecting the service or capability?', 'What is the current impact?'],
+    [INTAKE_MODE_IDS.GENERAL]: ['What is wrong, what affected item is involved, and how does it differ from expectation?', 'What is the current impact?'],
     [INTAKE_MODE_IDS.IT]: ['Which IT object is affected?', 'What is the current user or system impact?'],
     [INTAKE_MODE_IDS.PHARMA]: ['What quality event is affecting the product, process, or batch?', 'What is the current quality, release, safety, or patient impact?'],
     [INTAKE_MODE_IDS.MAJOR_INCIDENT]: ['What major incident is degrading which customer-facing service or capability?', 'What is the current incident impact and blast radius?']

--- a/tests/intakeModes.unit.test.mjs
+++ b/tests/intakeModes.unit.test.mjs
@@ -71,8 +71,8 @@ test('caption and helper override maps preserve stable field IDs for every mode'
 test('controlled fields use single-question labels and mode-appropriate helper guidance', () => {
   const expectedCopy = {
     [INTAKE_MODE_IDS.GENERAL]: {
-      oneLine: /problem.*service or capability/i,
-      objectPrefill: /which object is affected/i,
+      oneLine: /what is wrong.*affected item.*differ from expectation/i,
+      objectPrefill: /affected item or object/i,
       impactTime: /decision or resolution needed/i
     },
     [INTAKE_MODE_IDS.IT]: {
@@ -112,7 +112,7 @@ test('controlled fields use single-question labels and mode-appropriate helper g
 
 test('General, IT, and Pharma helpers guide operators to concrete answer details', () => {
   const guidancePatterns = {
-    [INTAKE_MODE_IDS.GENERAL]: /alerts.*measurements.*identifier.*scope.*deadline/is,
+    [INTAKE_MODE_IDS.GENERAL]: /for example.*product defect.*photos.*equipment item.*approved specification.*delivery date/is,
     [INTAKE_MODE_IDS.IT]: /logs.*metrics.*identifier.*scope.*SLA/is,
     [INTAKE_MODE_IDS.PHARMA]: /assay data.*identifier.*release.*hold points/is
   };
@@ -121,6 +121,25 @@ test('General, IT, and Pharma helpers guide operators to concrete answer details
     const helpers = Object.values(INTAKE_MODE_HELPER_OVERRIDES[modeId]).join(' ');
     assert.match(helpers, pattern, `${modeId} helpers should identify concrete evidence and decision details`);
   });
+});
+
+test('General captions and helpers support operational and non-technical intake', () => {
+  const captions = INTAKE_MODE_CAPTION_OVERRIDES[INTAKE_MODE_IDS.GENERAL];
+  const helpers = INTAKE_MODE_HELPER_OVERRIDES[INTAKE_MODE_IDS.GENERAL];
+
+  assert.match(captions.oneLine, /what is wrong.*affected item.*differ from expectation/i);
+  assert.match(captions.objectPrefill, /affected item or object/i);
+  assert.match(captions.healthy, /expected.*affected item/i);
+  assert.match(captions.now, /observed.*affected item/i);
+  assert.match(captions.proof, /evidence confirms the observed difference/i);
+  assert.match(captions.impactNow, /current impact/i);
+  assert.match(captions.impactFuture, /future impact.*unresolved/i);
+  assert.match(captions.impactTime, /decision or resolution needed/i);
+
+  Object.entries(helpers).forEach(([fieldId, helper]) => {
+    assert.match(helper, /^For example,/i, `General ${fieldId} helper should provide examples`);
+  });
+  assert.match(Object.values(helpers).join(' '), /product defect.*workflow.*equipment.*service/is);
 });
 
 test('IT and Major Incident use distinct operations and incident copy maps', () => {

--- a/tests/preface.feature.test.mjs
+++ b/tests/preface.feature.test.mjs
@@ -162,8 +162,8 @@ test('preface: mirrors KT fields, normalises containment, and updates titles', a
   objectPrefill.dispatchEvent(new window.Event('input', { bubbles: true }));
 
   assert.equal(objectISField.value, 'Edge Router service');
-  assert.equal(document.getElementById('labelNow').textContent, 'What is the object doing now?');
-  assert.equal(document.getElementById('labelHealthy').textContent, 'What should the object do normally?');
+  assert.equal(document.getElementById('labelNow').textContent, 'What condition or behavior is observed for the affected item now?');
+  assert.equal(document.getElementById('labelHealthy').textContent, 'What condition or behavior is expected for the affected item?');
   assert.equal(document.getElementById('docTitle').textContent, 'KT Intake');
   assert.equal(document.getElementById('docSubtitle').textContent, '');
   assert.equal(document.title, 'KT Intake');
@@ -183,15 +183,15 @@ test('preface: mirrors KT fields, normalises containment, and updates titles', a
   assert.equal(document.getElementById('docTitle').textContent, 'Edge Router service — Traffic drop for users');
   assert.equal(document.getElementById('docSubtitle').textContent, '');
   assert.equal(document.title, 'Edge Router service — Traffic drop for users · KT Intake');
-  assert.equal(document.getElementById('labelHealthy').textContent, 'What should the object do normally?');
+  assert.equal(document.getElementById('labelHealthy').textContent, 'What condition or behavior is expected for the affected item?');
 
   deviationISField.value = '';
   nowField.value = '';
   nowField.dispatchEvent(new window.Event('input', { bubbles: true }));
   assert.equal(document.getElementById('docTitle').textContent, 'KT Intake');
   assert.equal(document.getElementById('docSubtitle').textContent, '');
-  assert.equal(document.getElementById('labelNow').textContent, 'What is the object doing now?');
-  assert.equal(document.getElementById('labelHealthy').textContent, 'What should the object do normally?');
+  assert.equal(document.getElementById('labelNow').textContent, 'What condition or behavior is observed for the affected item now?');
+  assert.equal(document.getElementById('labelHealthy').textContent, 'What condition or behavior is expected for the affected item?');
   assert.equal(document.title, 'KT Intake');
 
   objectISField.value = '';
@@ -199,8 +199,8 @@ test('preface: mirrors KT fields, normalises containment, and updates titles', a
   objectPrefill.dispatchEvent(new window.Event('input', { bubbles: true }));
   assert.equal(document.getElementById('docTitle').textContent, 'KT Intake');
   assert.equal(document.getElementById('docSubtitle').textContent, '');
-  assert.equal(document.getElementById('labelNow').textContent, 'What is the object doing now?');
-  assert.equal(document.getElementById('labelHealthy').textContent, 'What should the object do normally?');
+  assert.equal(document.getElementById('labelNow').textContent, 'What condition or behavior is observed for the affected item now?');
+  assert.equal(document.getElementById('labelHealthy').textContent, 'What condition or behavior is expected for the affected item?');
 
   applyPrefaceState({
     ops: { containStatus: 'mitigation' }


### PR DESCRIPTION
### Motivation
- Make the General intake captions and helpers neutral and applicable to services, products, processes, equipment, workflows, or other items without presuming a service outage.
- Provide concrete, example-led helper guidance so non-technical and cross-domain users capture actionable evidence, impact, and timing details.

### Description
- Update `INTAKE_MODE_CAPTION_OVERRIDES.general` to use neutral wording that asks what is wrong, which affected item is involved, and how it differs from expectation, and to replace object/service-specific tokens with “affected item” wording.
- Replace `INTAKE_MODE_HELPER_OVERRIDES.general` entries with example-led guidance that shows concrete items to include (e.g., product defect, workflow delay, equipment fault, photos, measurements, deadlines) rather than repeating the label.
- Adjust DOM and unit test expectations to match the new neutral captions and helper style by updating `tests/intakeModes.unit.test.mjs`, `tests/intakeModeController.unit.test.mjs`, and `tests/preface.feature.test.mjs` and adding a unit that asserts example-led helpers for General mode.

### Testing
- Ran `npm test` and all suites passed after updating tests (final result: all tests green).
- Ran `npm run lint` with no lint errors reported.
- Ran `npm run verify:tests` to ensure coverage for the modified runtime behavior and it completed successfully.
- Verified `git diff --check` showed no trailing whitespace or patch issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a61231e90148324859ee97facc9d981)