### PR TITLE
Refine IT intake prompts and technical guidance

### DIFF
--- a/src/intakeModes.js
+++ b/src/intakeModes.js
@@ -164,9 +164,9 @@ export const INTAKE_MODE_CAPTION_OVERRIDES = deepFreeze({
     impactTime: 'When is a decision or resolution needed?'
   },
   [INTAKE_MODE_IDS.IT]: {
-    oneLine: 'What IT service or capability is degraded?',
-    proof: 'What evidence confirms the technical deviation?',
-    objectPrefill: 'Which IT object is affected?',
+    oneLine: 'What problem is affecting the service or system?',
+    proof: 'What observed evidence confirms the technical deviation?',
+    objectPrefill: 'Which system is affected?',
     healthy: 'What service behavior is expected?',
     now: 'What is the actual service behavior now?',
     impactNow: 'What is the current user or system impact?',
@@ -215,14 +215,14 @@ export const INTAKE_MODE_HELPER_OVERRIDES = deepFreeze({
     impactTime: 'For example, state a decision date, delivery date, dependency, deadline, or point of no return.'
   },
   [INTAKE_MODE_IDS.IT]: {
-    oneLine: 'State the degraded service or capability, symptom, and affected scope.',
+    oneLine: 'State the affected service or system, the problem, and the affected scope.',
     proof: 'Include alerts, logs, metrics, customer reports, or reproduction results.',
-    objectPrefill: 'Provide the service, application, dependency, host, OS, platform, version, or configuration identifier.',
-    healthy: 'Give the expected behavior, SLO, metric, or known-good configuration.',
+    objectPrefill: 'Include optional identification details such as the application, dependency, host, environment, version, or configuration.',
+    healthy: 'Give the expected baseline behavior, expected service target, metric, or known-good configuration. A service-level objective (SLO) is one type of expected service target.',
     now: 'Record current behavior, alerts, metrics, or user symptoms against the baseline.',
     impactNow: 'Identify affected users, transactions, regions, systems, or dependencies and quantify the scope.',
     impactFuture: 'Describe the operational risk, deadline, or dependent service at risk.',
-    impactTime: 'Include the applicable SLA, release, dependency, or other deadline.'
+    impactTime: 'Include the applicable service-level agreement (SLA), release, dependency, or other deadline.'
   },
   [INTAKE_MODE_IDS.PHARMA]: {
     oneLine: 'State the deviation, product or process context, and batch scope.',

--- a/tests/intakeModeController.unit.test.mjs
+++ b/tests/intakeModeController.unit.test.mjs
@@ -1,3 +1,6 @@
+/**
+ * @file Verifies intake-mode controller caption rendering and visibility behavior.
+ */
 import assert from 'node:assert/strict';
 import { afterEach, test } from 'node:test';
 import { JSDOM } from 'jsdom';
@@ -118,7 +121,7 @@ test('mode changes render representative question-led captions in the mounted DO
 
   const expected = {
     [INTAKE_MODE_IDS.GENERAL]: ['What is wrong, what affected item is involved, and how does it differ from expectation?', 'What is the current impact?'],
-    [INTAKE_MODE_IDS.IT]: ['Which IT object is affected?', 'What is the current user or system impact?'],
+    [INTAKE_MODE_IDS.IT]: ['Which system is affected?', 'What is the current user or system impact?'],
     [INTAKE_MODE_IDS.PHARMA]: ['What quality event is affecting the product, process, or batch?', 'What is the current quality, release, safety, or patient impact?'],
     [INTAKE_MODE_IDS.MAJOR_INCIDENT]: ['What major incident is degrading which customer-facing service or capability?', 'What is the current incident impact and blast radius?']
   };

--- a/tests/intakeModes.unit.test.mjs
+++ b/tests/intakeModes.unit.test.mjs
@@ -76,8 +76,9 @@ test('controlled fields use single-question labels and mode-appropriate helper g
       impactTime: /decision or resolution needed/i
     },
     [INTAKE_MODE_IDS.IT]: {
-      oneLine: /IT service or capability.*degraded/i,
-      objectPrefill: /which IT object is affected/i,
+      oneLine: /what problem is affecting the service or system/i,
+      proof: /observed evidence confirms the technical deviation/i,
+      objectPrefill: /which system is affected/i,
       impactTime: /decision or resolution needed/i
     },
     [INTAKE_MODE_IDS.PHARMA]: {
@@ -113,7 +114,7 @@ test('controlled fields use single-question labels and mode-appropriate helper g
 test('General, IT, and Pharma helpers guide operators to concrete answer details', () => {
   const guidancePatterns = {
     [INTAKE_MODE_IDS.GENERAL]: /for example.*product defect.*photos.*equipment item.*approved specification.*delivery date/is,
-    [INTAKE_MODE_IDS.IT]: /logs.*metrics.*identifier.*scope.*SLA/is,
+    [INTAKE_MODE_IDS.IT]: /scope.*logs.*metrics.*application.*dependency.*host.*environment.*version.*configuration.*service-level objective \(SLO\).*service-level agreement \(SLA\)/is,
     [INTAKE_MODE_IDS.PHARMA]: /assay data.*identifier.*release.*hold points/is
   };
 
@@ -121,6 +122,24 @@ test('General, IT, and Pharma helpers guide operators to concrete answer details
     const helpers = Object.values(INTAKE_MODE_HELPER_OVERRIDES[modeId]).join(' ');
     assert.match(helpers, pattern, `${modeId} helpers should identify concrete evidence and decision details`);
   });
+});
+
+test('IT primary questions stay plain-language while helpers define technical details', () => {
+  const captions = INTAKE_MODE_CAPTION_OVERRIDES[INTAKE_MODE_IDS.IT];
+  const helpers = INTAKE_MODE_HELPER_OVERRIDES[INTAKE_MODE_IDS.IT];
+
+  assert.equal(captions.oneLine, 'What problem is affecting the service or system?');
+  assert.equal(captions.objectPrefill, 'Which system is affected?');
+  assert.doesNotMatch(Object.values(captions).join(' '), /\b(?:IT|SLO|SLA|OS)\b/);
+  assert.match(helpers.objectPrefill, /application.*dependency.*host.*environment.*version.*configuration/i);
+  assert.match(helpers.healthy, /service-level objective \(SLO\)/i);
+  assert.match(helpers.impactTime, /service-level agreement \(SLA\)/i);
+  assert.match(captions.proof, /observed evidence/i);
+  assert.match(captions.healthy, /service behavior.*expected/i);
+  assert.match(captions.now, /actual service behavior now/i);
+  assert.match(captions.impactNow, /current user or system impact/i);
+  assert.match(captions.impactFuture, /future operational impact.*unresolved/i);
+  assert.match(captions.impactTime, /decision or resolution needed/i);
 });
 
 test('General captions and helpers support operational and non-technical intake', () => {

--- a/tests/summary.feature.test.mjs
+++ b/tests/summary.feature.test.mjs
@@ -380,8 +380,8 @@ test('summary: non-major modes use mode labels and exclude major-incident-only s
   const text = buildSummaryText(state);
 
   assert.ok(text.includes('— Technology Operations Summary —'));
-  assert.ok(text.includes('• What IT service or capability is degraded?: Checkout payments are failing'));
-  assert.ok(text.includes('• Which IT object is affected?: Payments API'));
+  assert.ok(text.includes('• What problem is affecting the service or system?: Checkout payments are failing'));
+  assert.ok(text.includes('• Which system is affected?: Payments API'));
   assert.ok(!text.includes('Operational evidence'));
   assert.ok(!text.includes('Synthetic monitor and logs confirm errors'));
   assert.ok(!text.includes('Detection Source'));


### PR DESCRIPTION
### Motivation
- Make IT intake questions plain-language and operator-friendly while keeping the technical detail available in helper guidance.
- Move optional identification details (application, dependency, host, environment, version, configuration) out of primary questions and into helper text.
- Avoid unexplained all-caps acronyms in primary labels by spelling out or introducing `SLO`/`SLA` in helper copy.
- Preserve useful distinctions for evidence, baseline behavior, current behavior, impact, future operational risk, and timing.

### Description
- Updated IT captions in `src/intakeModes.js` to use plain questions: `oneLine` is now `What problem is affecting the service or system?` and `objectPrefill` is `Which system is affected?`.
- Clarified `proof` caption to `What observed evidence confirms the technical deviation?` and kept the separate fields for `healthy`, `now`, `impactNow`, `impactFuture`, and `impactTime`.
- Moved detailed identification guidance into helpers in `src/intakeModes.js` and expanded helper copy to introduce/define `service-level objective (SLO)` and `service-level agreement (SLA)` on first use.
- Updated tests and fixtures to reflect the new copy: `tests/intakeModes.unit.test.mjs`, `tests/intakeModeController.unit.test.mjs`, and `tests/summary.feature.test.mjs` now assert the revised IT labels and helper patterns.

### Testing
- Ran `npm test` and the focused suites; automated tests passed after adjustments (all modified tests now succeed).
- Ran `npm run lint` for the changed files; lint completed with pre-existing JSDoc warnings in `src/intakeModes.js` but no new lint errors.
- Ran `npm run verify:tests` and `git diff --check`; verification succeeded and no diff-check problems were reported.
- Changed files: `src/intakeModes.js`, `tests/intakeModes.unit.test.mjs`, `tests/intakeModeController.unit.test.mjs`, and `tests/summary.feature.test.mjs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6124138f2883249b03827d44481d20)