### PR TITLE
Refine Pharma quality event intake guidance

### DIFF
--- a/src/intakeModes.js
+++ b/src/intakeModes.js
@@ -174,13 +174,13 @@ export const INTAKE_MODE_CAPTION_OVERRIDES = deepFreeze({
     impactTime: 'When is a decision or resolution needed?'
   },
   [INTAKE_MODE_IDS.PHARMA]: {
-    oneLine: 'What quality event is affecting the product, process, or batch?',
+    oneLine: 'What observed deviation affects which product, process, material, equipment, study, or batch?',
     proof: 'What evidence confirms the quality deviation?',
     objectPrefill: 'Which product, process, batch, material, or equipment is affected?',
     healthy: 'What validated or approved state is expected?',
     now: 'What condition is observed now?',
-    impactNow: 'What is the current quality, release, safety, or patient impact?',
-    impactFuture: 'What future compliance, stability, supply, or patient impact is likely if unresolved?',
+    impactNow: 'What confirmed current impact is known, or what is the current assessment status?',
+    impactFuture: 'What credible potential risk could arise if the deviation remains unresolved?',
     impactTime: 'When is a quality decision or resolution needed?'
   },
   [INTAKE_MODE_IDS.MAJOR_INCIDENT]: {
@@ -225,14 +225,14 @@ export const INTAKE_MODE_HELPER_OVERRIDES = deepFreeze({
     impactTime: 'Include the applicable service-level agreement (SLA), release, dependency, or other deadline.'
   },
   [INTAKE_MODE_IDS.PHARMA]: {
-    oneLine: 'State the deviation, product or process context, and batch scope.',
-    proof: 'Include inspection results, assay data, exceptions, complaints, or verified observations.',
-    objectPrefill: 'Provide the material, equipment, process step, study, product, or batch identifier.',
-    healthy: 'Give the approved specification, validated state, or control.',
-    now: 'Record the observed condition and its difference from the approved baseline.',
-    impactNow: 'Identify current quality, safety, release, or patient implications.',
-    impactFuture: 'Describe the likely compliance, stability, supply, or investigation risk.',
-    impactTime: 'Include hold points, release dates, or process deadlines.'
+    oneLine: 'State the observed deviation, affected product or process context, and batch or lot scope.',
+    proof: 'Include verified observations, inspection or assay results, exceptions, complaints, and supporting specification references.',
+    objectPrefill: 'Provide the product, material, equipment, process step, study, batch, or lot identifier.',
+    healthy: 'Give the approved specification, validated state, control, or documented acceptance criterion.',
+    now: 'Record the observed condition, its difference from the approved baseline, and the relevant specification reference.',
+    impactNow: 'Record confirmed current quality, release, or safety implications; if not known, state the assessment status and any batch hold or release status.',
+    impactFuture: 'Describe only credible potential risk if unresolved, with supporting rationale; include possible safety implications where applicable.',
+    impactTime: 'Include batch holds, release status, release dates, investigation milestones, or process deadlines.'
   },
   [INTAKE_MODE_IDS.MAJOR_INCIDENT]: {
     oneLine: 'Which major incident, degraded customer-facing service or capability, and scope should responders align on?',

--- a/tests/intakeModeController.unit.test.mjs
+++ b/tests/intakeModeController.unit.test.mjs
@@ -103,7 +103,7 @@ test('selector changes apply mode visibility and emit a save callback', () => {
   assert.equal(document.getElementById('evidenceCollected').hidden, true);
   assert.equal(document.getElementById('proofField').hidden, true);
   assert.equal(document.querySelector('label[for="proof"]').textContent, 'What evidence confirms the quality deviation?');
-  assert.equal(document.getElementById('impactNowHeading').textContent, 'What is the current quality, release, safety, or patient impact?');
+  assert.equal(document.getElementById('impactNowHeading').textContent, 'What confirmed current impact is known, or what is the current assessment status?');
 
   applyIntakeMode(INTAKE_MODE_IDS.MAJOR_INCIDENT, { silent: true });
   assert.equal(document.getElementById('commsDrawer').hidden, false);
@@ -122,7 +122,7 @@ test('mode changes render representative question-led captions in the mounted DO
   const expected = {
     [INTAKE_MODE_IDS.GENERAL]: ['What is wrong, what affected item is involved, and how does it differ from expectation?', 'What is the current impact?'],
     [INTAKE_MODE_IDS.IT]: ['Which system is affected?', 'What is the current user or system impact?'],
-    [INTAKE_MODE_IDS.PHARMA]: ['What quality event is affecting the product, process, or batch?', 'What is the current quality, release, safety, or patient impact?'],
+    [INTAKE_MODE_IDS.PHARMA]: ['What observed deviation affects which product, process, material, equipment, study, or batch?', 'What confirmed current impact is known, or what is the current assessment status?'],
     [INTAKE_MODE_IDS.MAJOR_INCIDENT]: ['What major incident is degrading which customer-facing service or capability?', 'What is the current incident impact and blast radius?']
   };
 

--- a/tests/intakeModes.unit.test.mjs
+++ b/tests/intakeModes.unit.test.mjs
@@ -82,7 +82,7 @@ test('controlled fields use single-question labels and mode-appropriate helper g
       impactTime: /decision or resolution needed/i
     },
     [INTAKE_MODE_IDS.PHARMA]: {
-      oneLine: /quality event.*product, process, or batch/i,
+      oneLine: /observed deviation.*product, process, material, equipment, study, or batch/i,
       proof: /evidence confirms the quality deviation/i,
       impactTime: /quality decision or resolution needed/i
     },
@@ -115,13 +115,28 @@ test('General, IT, and Pharma helpers guide operators to concrete answer details
   const guidancePatterns = {
     [INTAKE_MODE_IDS.GENERAL]: /for example.*product defect.*photos.*equipment item.*approved specification.*delivery date/is,
     [INTAKE_MODE_IDS.IT]: /scope.*logs.*metrics.*application.*dependency.*host.*environment.*version.*configuration.*service-level objective \(SLO\).*service-level agreement \(SLA\)/is,
-    [INTAKE_MODE_IDS.PHARMA]: /assay data.*identifier.*release.*hold points/is
+    [INTAKE_MODE_IDS.PHARMA]: /assay results.*specification references.*identifier.*batch hold.*release status/is
   };
 
   Object.entries(guidancePatterns).forEach(([modeId, pattern]) => {
     const helpers = Object.values(INTAKE_MODE_HELPER_OVERRIDES[modeId]).join(' ');
     assert.match(helpers, pattern, `${modeId} helpers should identify concrete evidence and decision details`);
   });
+});
+
+test('Pharma copy distinguishes confirmed impact, assessment status, and potential unresolved risk', () => {
+  const captions = INTAKE_MODE_CAPTION_OVERRIDES[INTAKE_MODE_IDS.PHARMA];
+  const helpers = INTAKE_MODE_HELPER_OVERRIDES[INTAKE_MODE_IDS.PHARMA];
+
+  assert.match(captions.oneLine, /observed deviation.*product.*process.*material.*equipment.*study.*batch/i);
+  assert.match(captions.impactNow, /confirmed current impact.*current assessment status/i);
+  assert.match(captions.impactFuture, /credible potential risk.*remains unresolved/i);
+  assert.doesNotMatch(captions.impactFuture, /(?:compliance|stability|supply|patient) impact is likely/i);
+  assert.match(helpers.oneLine, /batch or lot scope/i);
+  assert.match(helpers.proof, /specification references/i);
+  assert.match(helpers.objectPrefill, /batch, or lot identifier/i);
+  assert.match(helpers.impactNow, /assessment status.*batch hold or release status/i);
+  assert.match(helpers.impactFuture, /potential risk.*safety implications where applicable/i);
 });
 
 test('IT primary questions stay plain-language while helpers define technical details', () => {


### PR DESCRIPTION
### Motivation
- Clarify Pharma intake so the primary question centers on the observed deviation and the affected product/process/material/equipment/study/batch scope. 
- Distinguish confirmed current impact from an in-progress assessment and avoid implying unresolved impacts are already established. 
- Prompt operators for concrete evidence (batch/lot IDs, specification refs, release/hold status, safety notes) to support investigations and decisions.

### Description
- Update `INTAKE_MODE_CAPTION_OVERRIDES.pharma` to revise `oneLine`, `impactNow`, and `impactFuture` to focus on observed deviation, confirmed/current assessment status, and credible potential risk respectively. 
- Update `INTAKE_MODE_HELPER_OVERRIDES.pharma` to prompt for verified observations, inspection/assay results, specification references, batch/lot identifiers, release or hold status, investigation milestones, and applicable safety implications. 
- Keep all stable field IDs and persisted shape unchanged so existing `collectAppState()`/`applyAppState()` integrations remain valid. 
- Add and adjust unit and DOM tests in `tests/intakeModes.unit.test.mjs` and `tests/intakeModeController.unit.test.mjs` to assert the revised Pharma captions and helper guidance are rendered and enforce the evidence/impact constraints.

### Testing
- Ran `npm test -- tests/intakeModes.unit.test.mjs tests/intakeModeController.unit.test.mjs` and the targeted suites passed (full test run reported all tests passing for these suites). 
- Ran `npm run lint -- src/intakeModes.js tests/intakeModes.unit.test.mjs tests/intakeModeController.unit.test.mjs` which produced JSDoc warnings only and no lint errors. 
- Ran `npm run verify:tests` and the repository coverage guard completed (the script fell back to working-tree detection where the base branch was unavailable and did not block the change). 
- Confirmed the updated captions render in the controller integration checks and the new assertions in the unit suites succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6124ff71488324bf7b0c599ae9fd3d)