### PR TITLE
Refine intake impact timeframe guidance

### DIFF
--- a/src/intakeModes.js
+++ b/src/intakeModes.js
@@ -161,7 +161,7 @@ export const INTAKE_MODE_CAPTION_OVERRIDES = deepFreeze({
     now: 'What condition or behavior is observed for the affected item now?',
     impactNow: 'What is the current impact?',
     impactFuture: 'What future impact is likely if unresolved?',
-    impactTime: 'When is a decision or resolution needed?'
+    impactTime: 'When is action or resolution needed to avoid additional impact?'
   },
   [INTAKE_MODE_IDS.IT]: {
     oneLine: 'What problem is affecting the service or system?',
@@ -171,7 +171,7 @@ export const INTAKE_MODE_CAPTION_OVERRIDES = deepFreeze({
     now: 'What is the actual service behavior now?',
     impactNow: 'What is the current user or system impact?',
     impactFuture: 'What future operational impact is likely if unresolved?',
-    impactTime: 'When is a decision or resolution needed?'
+    impactTime: 'When is action or resolution needed to avoid additional impact?'
   },
   [INTAKE_MODE_IDS.PHARMA]: {
     oneLine: 'What observed deviation affects which product, process, material, equipment, study, or batch?',
@@ -181,7 +181,7 @@ export const INTAKE_MODE_CAPTION_OVERRIDES = deepFreeze({
     now: 'What condition is observed now?',
     impactNow: 'What confirmed current impact is known, or what is the current assessment status?',
     impactFuture: 'What credible potential risk could arise if the deviation remains unresolved?',
-    impactTime: 'When is a quality decision or resolution needed?'
+    impactTime: 'When is action or resolution needed to avoid additional impact?'
   },
   [INTAKE_MODE_IDS.MAJOR_INCIDENT]: {
     oneLine: 'What major incident is degrading which customer-facing service or capability?',
@@ -212,7 +212,7 @@ export const INTAKE_MODE_HELPER_OVERRIDES = deepFreeze({
     now: 'For example, record the observed defect, result, measurement, timing, or condition.',
     impactNow: 'For example, identify effects on people, output, cost, quality, safety, schedule, or availability.',
     impactFuture: 'For example, note likely rework, delay, loss, risk, or wider effect if unresolved.',
-    impactTime: 'For example, state a decision date, delivery date, dependency, deadline, or point of no return.'
+    impactTime: 'For example, complete the correction by 15 May before the month-end close; include the specific date or timeframe and the governing business or process deadline, dependency, milestone, or decision point.'
   },
   [INTAKE_MODE_IDS.IT]: {
     oneLine: 'State the affected service or system, the problem, and the affected scope.',
@@ -222,7 +222,7 @@ export const INTAKE_MODE_HELPER_OVERRIDES = deepFreeze({
     now: 'Record current behavior, alerts, metrics, or user symptoms against the baseline.',
     impactNow: 'Identify affected users, transactions, regions, systems, or dependencies and quantify the scope.',
     impactFuture: 'Describe the operational risk, deadline, or dependent service at risk.',
-    impactTime: 'Include the applicable service-level agreement (SLA), release, dependency, or other deadline.'
+    impactTime: 'For example, restore service before the 18:00 UTC release window; include the specific date or timeframe and the governing service-level agreement (SLA), release date, dependency, or decision point.'
   },
   [INTAKE_MODE_IDS.PHARMA]: {
     oneLine: 'State the observed deviation, affected product or process context, and batch or lot scope.',
@@ -232,7 +232,7 @@ export const INTAKE_MODE_HELPER_OVERRIDES = deepFreeze({
     now: 'Record the observed condition, its difference from the approved baseline, and the relevant specification reference.',
     impactNow: 'Record confirmed current quality, release, or safety implications; if not known, state the assessment status and any batch hold or release status.',
     impactFuture: 'Describe only credible potential risk if unresolved, with supporting rationale; include possible safety implications where applicable.',
-    impactTime: 'Include batch holds, release status, release dates, investigation milestones, or process deadlines.'
+    impactTime: 'For example, complete the assessment before batch release on 15 May; include the specific date or timeframe and the governing batch hold point, release date, process milestone or deadline, or decision point.'
   },
   [INTAKE_MODE_IDS.MAJOR_INCIDENT]: {
     oneLine: 'Which major incident, degraded customer-facing service or capability, and scope should responders align on?',

--- a/tests/intakeModes.unit.test.mjs
+++ b/tests/intakeModes.unit.test.mjs
@@ -73,18 +73,18 @@ test('controlled fields use single-question labels and mode-appropriate helper g
     [INTAKE_MODE_IDS.GENERAL]: {
       oneLine: /what is wrong.*affected item.*differ from expectation/i,
       objectPrefill: /affected item or object/i,
-      impactTime: /decision or resolution needed/i
+      impactTime: /action or resolution needed to avoid additional impact/i
     },
     [INTAKE_MODE_IDS.IT]: {
       oneLine: /what problem is affecting the service or system/i,
       proof: /observed evidence confirms the technical deviation/i,
       objectPrefill: /which system is affected/i,
-      impactTime: /decision or resolution needed/i
+      impactTime: /action or resolution needed to avoid additional impact/i
     },
     [INTAKE_MODE_IDS.PHARMA]: {
       oneLine: /observed deviation.*product, process, material, equipment, study, or batch/i,
       proof: /evidence confirms the quality deviation/i,
-      impactTime: /quality decision or resolution needed/i
+      impactTime: /action or resolution needed to avoid additional impact/i
     },
     [INTAKE_MODE_IDS.MAJOR_INCIDENT]: {
       oneLine: /major incident.*service or capability/i,
@@ -113,7 +113,7 @@ test('controlled fields use single-question labels and mode-appropriate helper g
 
 test('General, IT, and Pharma helpers guide operators to concrete answer details', () => {
   const guidancePatterns = {
-    [INTAKE_MODE_IDS.GENERAL]: /for example.*product defect.*photos.*equipment item.*approved specification.*delivery date/is,
+    [INTAKE_MODE_IDS.GENERAL]: /for example.*product defect.*photos.*equipment item.*approved specification.*business or process deadline/is,
     [INTAKE_MODE_IDS.IT]: /scope.*logs.*metrics.*application.*dependency.*host.*environment.*version.*configuration.*service-level objective \(SLO\).*service-level agreement \(SLA\)/is,
     [INTAKE_MODE_IDS.PHARMA]: /assay results.*specification references.*identifier.*batch hold.*release status/is
   };
@@ -121,6 +121,22 @@ test('General, IT, and Pharma helpers guide operators to concrete answer details
   Object.entries(guidancePatterns).forEach(([modeId, pattern]) => {
     const helpers = Object.values(INTAKE_MODE_HELPER_OVERRIDES[modeId]).join(' ');
     assert.match(helpers, pattern, `${modeId} helpers should identify concrete evidence and decision details`);
+  });
+});
+
+test('impact timeframe copy identifies the deadline that governs action for each intake mode', () => {
+  const expectedGuidance = {
+    [INTAKE_MODE_IDS.GENERAL]: /specific date or timeframe.*business or process deadline.*dependency.*milestone.*decision point/i,
+    [INTAKE_MODE_IDS.IT]: /specific date or timeframe.*service-level agreement \(SLA\).*release date.*dependency.*decision point/i,
+    [INTAKE_MODE_IDS.PHARMA]: /specific date or timeframe.*batch hold point.*release date.*process milestone or deadline.*decision point/i
+  };
+
+  Object.entries(expectedGuidance).forEach(([modeId, helperPattern]) => {
+    const { label, helper } = INTAKE_MODE_FIELD_CAPTIONS[modeId].impactTime;
+    assert.equal(label, 'When is action or resolution needed to avoid additional impact?');
+    assert.match(helper, /^For example,/i);
+    assert.match(helper, helperPattern);
+    assert.doesNotMatch(helper, /difficult, expensive, impossible, or meaningless/i);
   });
 });
 
@@ -154,7 +170,7 @@ test('IT primary questions stay plain-language while helpers define technical de
   assert.match(captions.now, /actual service behavior now/i);
   assert.match(captions.impactNow, /current user or system impact/i);
   assert.match(captions.impactFuture, /future operational impact.*unresolved/i);
-  assert.match(captions.impactTime, /decision or resolution needed/i);
+  assert.match(captions.impactTime, /action or resolution needed to avoid additional impact/i);
 });
 
 test('General captions and helpers support operational and non-technical intake', () => {
@@ -168,7 +184,7 @@ test('General captions and helpers support operational and non-technical intake'
   assert.match(captions.proof, /evidence confirms the observed difference/i);
   assert.match(captions.impactNow, /current impact/i);
   assert.match(captions.impactFuture, /future impact.*unresolved/i);
-  assert.match(captions.impactTime, /decision or resolution needed/i);
+  assert.match(captions.impactTime, /action or resolution needed to avoid additional impact/i);
 
   Object.entries(helpers).forEach(([fieldId, helper]) => {
     assert.match(helper, /^For example,/i, `General ${fieldId} helper should provide examples`);

--- a/tests/summary.feature.test.mjs
+++ b/tests/summary.feature.test.mjs
@@ -388,7 +388,7 @@ test('summary: non-major modes use mode labels and exclude major-incident-only s
   assert.ok(!text.includes('Evidence Collected'));
   assert.ok(text.includes('What is the current user or system impact?: Customers cannot complete checkout'));
   assert.ok(text.includes('What future operational impact is likely if unresolved?: Backlog may trigger order cancellations'));
-  assert.ok(text.includes('When is a decision or resolution needed?: Detected at 12:45 UTC'));
+  assert.ok(text.includes('When is action or resolution needed to avoid additional impact?: Detected at 12:45 UTC'));
   assert.ok(text.includes('— Problem Analysis —'));
   assert.ok(text.includes('— Possible Causes —'));
   assert.ok(text.includes('Likely Cause:'));


### PR DESCRIPTION
### Motivation
- Clarify the `impactTime` prompt so operators provide a concrete deadline for action rather than a generic urgency phrase. 
- Capture the governing deadline/dependency for decisions (e.g., business deadline, SLA/release window, batch hold/release) so downstream responders can prioritise appropriately.

### Description
- Replaced `impactTime` labels for `General`, `IT`, and `Pharma` modes in `src/intakeModes.js` with an action-focused question: `When is action or resolution needed to avoid additional impact?`.
- Rewrote the `impactTime` helper text for each mode to request a specific date/timeframe and the governing dependency, milestone, hold point, release date, SLA, or decision point with tailored examples for General, IT, and Pharma.
- Updated unit and feature tests to expect the new label and helper guidance and added an assertion that each non-major mode helper includes the required mode-specific deadline details in `tests/intakeModes.unit.test.mjs` and `tests/summary.feature.test.mjs`.
- Changes committed on the current branch as `Refine intake impact timeframe guidance` and include edits to `src/intakeModes.js`, `tests/intakeModes.unit.test.mjs`, and `tests/summary.feature.test.mjs`.

### Testing
- Ran `npm test` and the repository test suite completed successfully (all tests passing after updates). 
- Ran `npm run lint` and the lint step passed with no reported errors. 
- Ran `npm run verify:tests` and the coverage/verification guard accepted the updated tests. 
- Ran `git diff --check` and no whitespace/diff issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a61263ab7d08324b23bdc1c9c258229)