### PR TITLE
Simplify intake-mode copy, use fixed ‘Timeframe’ label in summary, and update tests

### DIFF
--- a/src/intakeModes.js
+++ b/src/intakeModes.js
@@ -154,44 +154,44 @@ export const INTAKE_MODE_SECTION_VISIBILITY = deepFreeze({
  */
 export const INTAKE_MODE_CAPTION_OVERRIDES = deepFreeze({
   [INTAKE_MODE_IDS.GENERAL]: {
-    oneLine: 'What is wrong, what affected item is involved, and how does it differ from expectation?',
-    proof: 'What evidence confirms the observed difference?',
-    objectPrefill: 'Which affected item or object should be examined?',
-    healthy: 'What condition or behavior is expected for the affected item?',
-    now: 'What condition or behavior is observed for the affected item now?',
-    impactNow: 'What is the current impact?',
-    impactFuture: 'What future impact is likely if unresolved?',
-    impactTime: 'When is action or resolution needed to avoid additional impact?'
+    oneLine: 'What item is affected, and what is wrong with it?',
+    proof: 'What evidence shows that the problem is real?',
+    objectPrefill: 'What specific item should we examine?',
+    healthy: 'What should normally happen?',
+    now: 'What is happening instead?',
+    impactNow: 'What impact is the problem causing now?',
+    impactFuture: 'What could happen if no effective action is taken?',
+    impactTime: 'By when must action be taken before the impact gets worse?'
   },
   [INTAKE_MODE_IDS.IT]: {
-    oneLine: 'What problem is affecting the service or system?',
-    proof: 'What observed evidence confirms the technical deviation?',
-    objectPrefill: 'Which system is affected?',
-    healthy: 'What service behavior is expected?',
-    now: 'What is the actual service behavior now?',
-    impactNow: 'What is the current user or system impact?',
-    impactFuture: 'What future operational impact is likely if unresolved?',
-    impactTime: 'When is action or resolution needed to avoid additional impact?'
+    oneLine: 'What service or system is affected, and what is it doing wrong?',
+    proof: 'What evidence confirms the incident?',
+    objectPrefill: 'What specific system or service is affected?',
+    healthy: 'What should the service normally do?',
+    now: 'What is the service doing now?',
+    impactNow: 'Who or what is affected right now?',
+    impactFuture: 'What additional impact could occur if the incident continues?',
+    impactTime: 'What is the next deadline or event before the impact becomes worse?'
   },
   [INTAKE_MODE_IDS.PHARMA]: {
-    oneLine: 'What observed deviation affects which product, process, material, equipment, study, or batch?',
-    proof: 'What evidence confirms the quality deviation?',
-    objectPrefill: 'Which product, process, batch, material, or equipment is affected?',
-    healthy: 'What validated or approved state is expected?',
-    now: 'What condition is observed now?',
-    impactNow: 'What confirmed current impact is known, or what is the current assessment status?',
-    impactFuture: 'What credible potential risk could arise if the deviation remains unresolved?',
-    impactTime: 'When is action or resolution needed to avoid additional impact?'
+    oneLine: 'What unexpected condition was observed, and what product, batch, process, material, or equipment may be affected?',
+    proof: 'What records or observations confirm the event?',
+    objectPrefill: 'What specific product, batch, material, process, or equipment may be affected?',
+    healthy: 'What approved requirement should have been met?',
+    now: 'What was observed instead?',
+    impactNow: 'What impact is confirmed now, and what is still being assessed?',
+    impactFuture: 'What credible risk could arise if the event is not contained or addressed?',
+    impactTime: 'By when must containment, assessment, or a decision occur?'
   },
   [INTAKE_MODE_IDS.MAJOR_INCIDENT]: {
-    oneLine: 'What major incident is degrading which customer-facing service or capability?',
-    proof: 'What observable or measurable evidence confirms the incident deviation?',
-    objectPrefill: 'Which specific service, platform, region, or workflow object is affected?',
-    healthy: 'What known-good behavior is expected, and what baseline should responders use?',
-    now: 'What actual behavior are responders seeing now, and how does it differ from the baseline?',
-    impactNow: 'What is the current incident impact and blast radius?',
-    impactFuture: 'What future incident impact is likely if containment does not improve?',
-    impactTime: 'By what incident deadline or timeframe does resolution become difficult, expensive, impossible, or meaningless?'
+    oneLine: 'What critical service or business capability is affected, and what is happening?',
+    proof: 'What current evidence confirms the incident?',
+    objectPrefill: 'What specific service, region, platform, or customer journey is affected?',
+    healthy: 'What should customers, users, or the business normally experience?',
+    now: 'What is happening right now?',
+    impactNow: 'Who cannot do what right now?',
+    impactFuture: 'What could happen next if the incident continues or spreads?',
+    impactTime: 'What is the next hard deadline before the impact becomes much worse?'
   }
 });
 
@@ -205,44 +205,44 @@ export const INTAKE_MODE_CAPTION_OVERRIDES = deepFreeze({
  */
 export const INTAKE_MODE_HELPER_OVERRIDES = deepFreeze({
   [INTAKE_MODE_IDS.GENERAL]: {
-    oneLine: 'For example, describe a product defect, delayed workflow, equipment fault, or unexpected service result.',
-    proof: 'For example, include observations, measurements, photos, reports, test results, or user feedback.',
-    objectPrefill: 'For example, name a product, process step, equipment item, workflow, document, or service.',
-    healthy: 'For example, note the approved specification, expected result, normal timing, or prior condition.',
-    now: 'For example, record the observed defect, result, measurement, timing, or condition.',
-    impactNow: 'For example, identify effects on people, output, cost, quality, safety, schedule, or availability.',
-    impactFuture: 'For example, note likely rework, delay, loss, risk, or wider effect if unresolved.',
-    impactTime: 'For example, complete the correction by 15 May before the month-end close; include the specific date or timeframe and the governing business or process deadline, dependency, milestone, or decision point.'
+    oneLine: 'Describe one item and one clear difference from what should be happening. Do not include the cause or solution.',
+    proof: 'Include observations, measurements, photos, test results, reports, or feedback.',
+    objectPrefill: 'Name the product, part, machine, process step, workflow, document, or service. Include an ID or location if helpful.',
+    healthy: 'State the expected condition, result, measurement, timing, or approved requirement.',
+    now: 'Describe the actual condition and how much it differs from what is expected. Include when and how often it occurs.',
+    impactNow: 'Consider people, safety, quality, output, customers, cost, schedule, or availability.',
+    impactFuture: 'Describe the most likely additional impact, not only the worst possible outcome.',
+    impactTime: 'Give a date, time, deadline, or event, and explain what changes after that point.'
   },
   [INTAKE_MODE_IDS.IT]: {
-    oneLine: 'State the affected service or system, the problem, and the affected scope.',
-    proof: 'Include alerts, logs, metrics, customer reports, or reproduction results.',
-    objectPrefill: 'Include optional identification details such as the application, dependency, host, environment, version, or configuration.',
-    healthy: 'Give the expected baseline behavior, expected service target, metric, or known-good configuration. A service-level objective (SLO) is one type of expected service target.',
-    now: 'Record current behavior, alerts, metrics, or user symptoms against the baseline.',
-    impactNow: 'Identify affected users, transactions, regions, systems, or dependencies and quantify the scope.',
-    impactFuture: 'Describe the operational risk, deadline, or dependent service at risk.',
-    impactTime: 'For example, restore service before the 18:00 UTC release window; include the specific date or timeframe and the governing service-level agreement (SLA), release date, dependency, or decision point.'
+    oneLine: 'State the affected service, the problem users or systems are seeing, and the known scope. Do not include a suspected cause.',
+    proof: 'Include alerts, logs, metrics, error messages, test results, or user reports. Add the time observed when possible.',
+    objectPrefill: 'Name the application, service, API, database, host, network, environment, region, or version.',
+    healthy: 'State the expected user result, system behaviour, performance level, service target, or known-good condition.',
+    now: 'Describe the symptoms, errors, measurements, timing, and whether the condition is improving, stable, or getting worse.',
+    impactNow: 'Identify affected users, transactions, regions, systems, or business activities. Include the size of the impact and any usable workaround.',
+    impactFuture: 'Consider growing backlogs, missed deadlines, dependent systems, data issues, customer impact, or loss of service.',
+    impactTime: 'Give the specific time and consequence, such as a processing cutoff, release window, capacity limit, or business deadline.'
   },
   [INTAKE_MODE_IDS.PHARMA]: {
-    oneLine: 'State the observed deviation, affected product or process context, and batch or lot scope.',
-    proof: 'Include verified observations, inspection or assay results, exceptions, complaints, and supporting specification references.',
-    objectPrefill: 'Provide the product, material, equipment, process step, study, batch, or lot identifier.',
-    healthy: 'Give the approved specification, validated state, control, or documented acceptance criterion.',
-    now: 'Record the observed condition, its difference from the approved baseline, and the relevant specification reference.',
-    impactNow: 'Record confirmed current quality, release, or safety implications; if not known, state the assessment status and any batch hold or release status.',
-    impactFuture: 'Describe only credible potential risk if unresolved, with supporting rationale; include possible safety implications where applicable.',
-    impactTime: 'For example, complete the assessment before batch release on 15 May; include the specific date or timeframe and the governing batch hold point, release date, process milestone or deadline, or decision point.'
+    oneLine: 'State what was observed and the initial scope. Do not include an assumed cause or unconfirmed product impact.',
+    proof: 'Include test results, batch records, instrument data, inspection findings, complaints, photos, or direct observations.',
+    objectPrefill: 'Include the product name, batch or lot number, equipment ID, process step, site, line, room, sample, or study.',
+    healthy: 'State the applicable specification, validated range, procedure, batch record, method, protocol, or acceptance limit.',
+    now: 'Record the actual condition or result, how it differs from the requirement, and when it occurred. Keep retest results separate from the original result.',
+    impactNow: 'State known quality, safety, release, or data implications. Include whether the batch is on hold, released, distributed, or still under review.',
+    impactFuture: 'Consider patients, product quality, other batches, recurrence, contamination, data validity, supply, or regulatory impact. Do not present possible harm as confirmed harm.',
+    impactTime: 'Give the relevant hold point, release date, manufacturing step, shipment, reporting deadline, or other decision point.'
   },
   [INTAKE_MODE_IDS.MAJOR_INCIDENT]: {
-    oneLine: 'Which major incident, degraded customer-facing service or capability, and scope should responders align on?',
-    proof: 'Which alerts, metrics, reports, screenshots, or logs demonstrate the incident deviation?',
-    objectPrefill: 'Which customer-facing service, platform, region, workflow, or configuration details distinguish the affected object?',
-    healthy: 'Which known-good behavior, metric, or service baseline should responders use for comparison?',
-    now: 'Which active behavior, measurements, or customer symptoms show the difference from that baseline?',
-    impactNow: 'Which customers, services, regions, or business functions are affected now, and what is the blast radius?',
-    impactFuture: 'Which near-term escalation or customer impact is likely if containment does not improve?',
-    impactTime: 'When do recovery commitments, updates, or business deadlines make resolution difficult, expensive, impossible, or meaningless?'
+    oneLine: 'State the affected capability, the current problem, and the confirmed scope. Do not include a suspected cause.',
+    proof: 'Include alerts, metrics, logs, test results, transaction failures, screenshots, or customer reports. Add the observation time.',
+    objectPrefill: 'Identify the exact service, transaction path, environment, region, customer group, release, or configuration. Include what is known to be unaffected when helpful.',
+    healthy: 'State the expected result and any useful baseline, such as success rate, response time, availability, throughput, or known-good condition.',
+    now: 'Describe the current symptoms, measurements, scope, mitigation status, and whether the incident is improving, stable, or getting worse. Include an “as of” time.',
+    impactNow: 'Quantify affected customers, users, transactions, regions, services, or business functions. Include any workaround.',
+    impactFuture: 'Consider growing customer impact, backlogs, dependent-service failures, capacity limits, data issues, missed deadlines, or fewer recovery options.',
+    impactTime: 'Give the exact time, event, or threshold and explain the consequence. Track communication update times separately.'
   }
 });
 

--- a/src/summary.js
+++ b/src/summary.js
@@ -1049,7 +1049,7 @@ export function buildSummaryText(stateInput, options = {}){
   const impactLines = [
     summaryLine(captionLabel('impactNow', 'Current Impact'), impactNow?.value ?? document.getElementById('impactNow')?.value),
     summaryLine(captionLabel('impactFuture', 'Future Impact'), impactFuture?.value ?? document.getElementById('impactFuture')?.value),
-    summaryLine(captionLabel('impactTime', 'Timeframe'), impactTime?.value ?? document.getElementById('impactTime')?.value)
+    summaryLine('Timeframe', impactTime?.value ?? document.getElementById('impactTime')?.value)
   ];
   const imp = joinSummaryLines(impactLines);
 

--- a/tests/intakeModeController.unit.test.mjs
+++ b/tests/intakeModeController.unit.test.mjs
@@ -102,8 +102,8 @@ test('selector changes apply mode visibility and emit a save callback', () => {
   assert.equal(document.getElementById('detectionSource').hidden, true);
   assert.equal(document.getElementById('evidenceCollected').hidden, true);
   assert.equal(document.getElementById('proofField').hidden, true);
-  assert.equal(document.querySelector('label[for="proof"]').textContent, 'What evidence confirms the quality deviation?');
-  assert.equal(document.getElementById('impactNowHeading').textContent, 'What confirmed current impact is known, or what is the current assessment status?');
+  assert.equal(document.querySelector('label[for="proof"]').textContent, 'What records or observations confirm the event?');
+  assert.equal(document.getElementById('impactNowHeading').textContent, 'What impact is confirmed now, and what is still being assessed?');
 
   applyIntakeMode(INTAKE_MODE_IDS.MAJOR_INCIDENT, { silent: true });
   assert.equal(document.getElementById('commsDrawer').hidden, false);
@@ -120,10 +120,10 @@ test('mode changes render representative question-led captions in the mounted DO
   initIntakeModeController();
 
   const expected = {
-    [INTAKE_MODE_IDS.GENERAL]: ['What is wrong, what affected item is involved, and how does it differ from expectation?', 'What is the current impact?'],
-    [INTAKE_MODE_IDS.IT]: ['Which system is affected?', 'What is the current user or system impact?'],
-    [INTAKE_MODE_IDS.PHARMA]: ['What observed deviation affects which product, process, material, equipment, study, or batch?', 'What confirmed current impact is known, or what is the current assessment status?'],
-    [INTAKE_MODE_IDS.MAJOR_INCIDENT]: ['What major incident is degrading which customer-facing service or capability?', 'What is the current incident impact and blast radius?']
+    [INTAKE_MODE_IDS.GENERAL]: ['What item is affected, and what is wrong with it?', 'What impact is the problem causing now?'],
+    [INTAKE_MODE_IDS.IT]: ['What specific system or service is affected?', 'Who or what is affected right now?'],
+    [INTAKE_MODE_IDS.PHARMA]: ['What unexpected condition was observed, and what product, batch, process, material, or equipment may be affected?', 'What impact is confirmed now, and what is still being assessed?'],
+    [INTAKE_MODE_IDS.MAJOR_INCIDENT]: ['What critical service or business capability is affected, and what is happening?', 'Who cannot do what right now?']
   };
 
   Object.entries(expected).forEach(([modeId, [labelText, headingText]]) => {

--- a/tests/intakeModes.unit.test.mjs
+++ b/tests/intakeModes.unit.test.mjs
@@ -68,154 +68,44 @@ test('caption and helper override maps preserve stable field IDs for every mode'
 });
 
 
-test('controlled fields use single-question labels and mode-appropriate helper guidance', () => {
+test('each mode exposes the approved simplified intake questions and helpers', () => {
   const expectedCopy = {
     [INTAKE_MODE_IDS.GENERAL]: {
-      oneLine: /what is wrong.*affected item.*differ from expectation/i,
-      objectPrefill: /affected item or object/i,
-      impactTime: /action or resolution needed to avoid additional impact/i
+      oneLine: ['What item is affected, and what is wrong with it?', 'Describe one item and one clear difference from what should be happening. Do not include the cause or solution.'],
+      impactTime: ['By when must action be taken before the impact gets worse?', 'Give a date, time, deadline, or event, and explain what changes after that point.']
     },
     [INTAKE_MODE_IDS.IT]: {
-      oneLine: /what problem is affecting the service or system/i,
-      proof: /observed evidence confirms the technical deviation/i,
-      objectPrefill: /which system is affected/i,
-      impactTime: /action or resolution needed to avoid additional impact/i
+      oneLine: ['What service or system is affected, and what is it doing wrong?', 'State the affected service, the problem users or systems are seeing, and the known scope. Do not include a suspected cause.'],
+      impactTime: ['What is the next deadline or event before the impact becomes worse?', 'Give the specific time and consequence, such as a processing cutoff, release window, capacity limit, or business deadline.']
     },
     [INTAKE_MODE_IDS.PHARMA]: {
-      oneLine: /observed deviation.*product, process, material, equipment, study, or batch/i,
-      proof: /evidence confirms the quality deviation/i,
-      impactTime: /action or resolution needed to avoid additional impact/i
+      oneLine: ['What unexpected condition was observed, and what product, batch, process, material, or equipment may be affected?', 'State what was observed and the initial scope. Do not include an assumed cause or unconfirmed product impact.'],
+      impactTime: ['By when must containment, assessment, or a decision occur?', 'Give the relevant hold point, release date, manufacturing step, shipment, reporting deadline, or other decision point.']
     },
     [INTAKE_MODE_IDS.MAJOR_INCIDENT]: {
-      oneLine: /major incident.*service or capability/i,
-      now: /differ from the baseline/i,
-      impactTime: /difficult, expensive, impossible, or meaningless/i
+      oneLine: ['What critical service or business capability is affected, and what is happening?', 'State the affected capability, the current problem, and the confirmed scope. Do not include a suspected cause.'],
+      impactTime: ['What is the next hard deadline before the impact becomes much worse?', 'Give the exact time, event, or threshold and explain the consequence. Track communication update times separately.']
     }
   };
 
+  Object.entries(expectedCopy).forEach(([modeId, fields]) => {
+    Object.entries(fields).forEach(([fieldId, [label, helper]]) => {
+      assert.equal(INTAKE_MODE_CAPTION_OVERRIDES[modeId][fieldId], label);
+      assert.equal(INTAKE_MODE_HELPER_OVERRIDES[modeId][fieldId], helper);
+    });
+  });
+});
+
+test('every simplified prompt retains a question label and directive helper text', () => {
   Object.values(INTAKE_MODE_IDS).forEach((modeId) => {
     REQUIRED_FIELD_IDS.forEach((fieldId) => {
       const { label, helper } = INTAKE_MODE_FIELD_CAPTIONS[modeId][fieldId];
       assert.match(label, /\?$/, `${modeId}.${fieldId} label should be a question`);
-      if (modeId === INTAKE_MODE_IDS.MAJOR_INCIDENT) {
-        assert.match(helper, /\?$/, `${modeId}.${fieldId} helper should be a question`);
-      } else {
-        assert.doesNotMatch(helper, /\?$/, `${modeId}.${fieldId} helper should be concise guidance, not a question`);
-      }
+      assert.doesNotMatch(helper, /\?$/, `${modeId}.${fieldId} helper should be direct guidance`);
       assert.equal(label, INTAKE_MODE_CAPTION_OVERRIDES[modeId][fieldId]);
       assert.equal(helper, INTAKE_MODE_HELPER_OVERRIDES[modeId][fieldId]);
     });
-    Object.entries(expectedCopy[modeId]).forEach(([fieldId, pattern]) => {
-      assert.match(INTAKE_MODE_FIELD_CAPTIONS[modeId][fieldId].label, pattern);
-    });
   });
-});
-
-test('General, IT, and Pharma helpers guide operators to concrete answer details', () => {
-  const guidancePatterns = {
-    [INTAKE_MODE_IDS.GENERAL]: /for example.*product defect.*photos.*equipment item.*approved specification.*business or process deadline/is,
-    [INTAKE_MODE_IDS.IT]: /scope.*logs.*metrics.*application.*dependency.*host.*environment.*version.*configuration.*service-level objective \(SLO\).*service-level agreement \(SLA\)/is,
-    [INTAKE_MODE_IDS.PHARMA]: /assay results.*specification references.*identifier.*batch hold.*release status/is
-  };
-
-  Object.entries(guidancePatterns).forEach(([modeId, pattern]) => {
-    const helpers = Object.values(INTAKE_MODE_HELPER_OVERRIDES[modeId]).join(' ');
-    assert.match(helpers, pattern, `${modeId} helpers should identify concrete evidence and decision details`);
-  });
-});
-
-test('impact timeframe copy identifies the deadline that governs action for each intake mode', () => {
-  const expectedGuidance = {
-    [INTAKE_MODE_IDS.GENERAL]: /specific date or timeframe.*business or process deadline.*dependency.*milestone.*decision point/i,
-    [INTAKE_MODE_IDS.IT]: /specific date or timeframe.*service-level agreement \(SLA\).*release date.*dependency.*decision point/i,
-    [INTAKE_MODE_IDS.PHARMA]: /specific date or timeframe.*batch hold point.*release date.*process milestone or deadline.*decision point/i
-  };
-
-  Object.entries(expectedGuidance).forEach(([modeId, helperPattern]) => {
-    const { label, helper } = INTAKE_MODE_FIELD_CAPTIONS[modeId].impactTime;
-    assert.equal(label, 'When is action or resolution needed to avoid additional impact?');
-    assert.match(helper, /^For example,/i);
-    assert.match(helper, helperPattern);
-    assert.doesNotMatch(helper, /difficult, expensive, impossible, or meaningless/i);
-  });
-});
-
-test('Pharma copy distinguishes confirmed impact, assessment status, and potential unresolved risk', () => {
-  const captions = INTAKE_MODE_CAPTION_OVERRIDES[INTAKE_MODE_IDS.PHARMA];
-  const helpers = INTAKE_MODE_HELPER_OVERRIDES[INTAKE_MODE_IDS.PHARMA];
-
-  assert.match(captions.oneLine, /observed deviation.*product.*process.*material.*equipment.*study.*batch/i);
-  assert.match(captions.impactNow, /confirmed current impact.*current assessment status/i);
-  assert.match(captions.impactFuture, /credible potential risk.*remains unresolved/i);
-  assert.doesNotMatch(captions.impactFuture, /(?:compliance|stability|supply|patient) impact is likely/i);
-  assert.match(helpers.oneLine, /batch or lot scope/i);
-  assert.match(helpers.proof, /specification references/i);
-  assert.match(helpers.objectPrefill, /batch, or lot identifier/i);
-  assert.match(helpers.impactNow, /assessment status.*batch hold or release status/i);
-  assert.match(helpers.impactFuture, /potential risk.*safety implications where applicable/i);
-});
-
-test('IT primary questions stay plain-language while helpers define technical details', () => {
-  const captions = INTAKE_MODE_CAPTION_OVERRIDES[INTAKE_MODE_IDS.IT];
-  const helpers = INTAKE_MODE_HELPER_OVERRIDES[INTAKE_MODE_IDS.IT];
-
-  assert.equal(captions.oneLine, 'What problem is affecting the service or system?');
-  assert.equal(captions.objectPrefill, 'Which system is affected?');
-  assert.doesNotMatch(Object.values(captions).join(' '), /\b(?:IT|SLO|SLA|OS)\b/);
-  assert.match(helpers.objectPrefill, /application.*dependency.*host.*environment.*version.*configuration/i);
-  assert.match(helpers.healthy, /service-level objective \(SLO\)/i);
-  assert.match(helpers.impactTime, /service-level agreement \(SLA\)/i);
-  assert.match(captions.proof, /observed evidence/i);
-  assert.match(captions.healthy, /service behavior.*expected/i);
-  assert.match(captions.now, /actual service behavior now/i);
-  assert.match(captions.impactNow, /current user or system impact/i);
-  assert.match(captions.impactFuture, /future operational impact.*unresolved/i);
-  assert.match(captions.impactTime, /action or resolution needed to avoid additional impact/i);
-});
-
-test('General captions and helpers support operational and non-technical intake', () => {
-  const captions = INTAKE_MODE_CAPTION_OVERRIDES[INTAKE_MODE_IDS.GENERAL];
-  const helpers = INTAKE_MODE_HELPER_OVERRIDES[INTAKE_MODE_IDS.GENERAL];
-
-  assert.match(captions.oneLine, /what is wrong.*affected item.*differ from expectation/i);
-  assert.match(captions.objectPrefill, /affected item or object/i);
-  assert.match(captions.healthy, /expected.*affected item/i);
-  assert.match(captions.now, /observed.*affected item/i);
-  assert.match(captions.proof, /evidence confirms the observed difference/i);
-  assert.match(captions.impactNow, /current impact/i);
-  assert.match(captions.impactFuture, /future impact.*unresolved/i);
-  assert.match(captions.impactTime, /action or resolution needed to avoid additional impact/i);
-
-  Object.entries(helpers).forEach(([fieldId, helper]) => {
-    assert.match(helper, /^For example,/i, `General ${fieldId} helper should provide examples`);
-  });
-  assert.match(Object.values(helpers).join(' '), /product defect.*workflow.*equipment.*service/is);
-});
-
-test('IT and Major Incident use distinct operations and incident copy maps', () => {
-  assert.notDeepEqual(
-    INTAKE_MODE_CAPTION_OVERRIDES[INTAKE_MODE_IDS.IT],
-    INTAKE_MODE_CAPTION_OVERRIDES[INTAKE_MODE_IDS.MAJOR_INCIDENT]
-  );
-  assert.notDeepEqual(
-    INTAKE_MODE_HELPER_OVERRIDES[INTAKE_MODE_IDS.IT],
-    INTAKE_MODE_HELPER_OVERRIDES[INTAKE_MODE_IDS.MAJOR_INCIDENT]
-  );
-
-  const itCopy = [
-    ...Object.values(INTAKE_MODE_CAPTION_OVERRIDES[INTAKE_MODE_IDS.IT]),
-    ...Object.values(INTAKE_MODE_HELPER_OVERRIDES[INTAKE_MODE_IDS.IT])
-  ].join(' ');
-  assert.doesNotMatch(itCopy, /\b(bridge|comms|communications|handover)\b/i);
-  assert.match(itCopy, /technical deviation/i);
-
-  const majorIncidentCopy = [
-    ...Object.values(INTAKE_MODE_CAPTION_OVERRIDES[INTAKE_MODE_IDS.MAJOR_INCIDENT]),
-    ...Object.values(INTAKE_MODE_HELPER_OVERRIDES[INTAKE_MODE_IDS.MAJOR_INCIDENT])
-  ].join(' ');
-  assert.match(majorIncidentCopy, /major incident/i);
-  assert.match(majorIncidentCopy, /responders/i);
-  assert.match(majorIncidentCopy, /blast radius/i);
 });
 
 test('IT keeps the same minimal visible sections as General and Pharma', () => {

--- a/tests/preface.feature.test.mjs
+++ b/tests/preface.feature.test.mjs
@@ -162,8 +162,8 @@ test('preface: mirrors KT fields, normalises containment, and updates titles', a
   objectPrefill.dispatchEvent(new window.Event('input', { bubbles: true }));
 
   assert.equal(objectISField.value, 'Edge Router service');
-  assert.equal(document.getElementById('labelNow').textContent, 'What condition or behavior is observed for the affected item now?');
-  assert.equal(document.getElementById('labelHealthy').textContent, 'What condition or behavior is expected for the affected item?');
+  assert.equal(document.getElementById('labelNow').textContent, 'What is happening instead?');
+  assert.equal(document.getElementById('labelHealthy').textContent, 'What should normally happen?');
   assert.equal(document.getElementById('docTitle').textContent, 'KT Intake');
   assert.equal(document.getElementById('docSubtitle').textContent, '');
   assert.equal(document.title, 'KT Intake');
@@ -183,15 +183,15 @@ test('preface: mirrors KT fields, normalises containment, and updates titles', a
   assert.equal(document.getElementById('docTitle').textContent, 'Edge Router service — Traffic drop for users');
   assert.equal(document.getElementById('docSubtitle').textContent, '');
   assert.equal(document.title, 'Edge Router service — Traffic drop for users · KT Intake');
-  assert.equal(document.getElementById('labelHealthy').textContent, 'What condition or behavior is expected for the affected item?');
+  assert.equal(document.getElementById('labelHealthy').textContent, 'What should normally happen?');
 
   deviationISField.value = '';
   nowField.value = '';
   nowField.dispatchEvent(new window.Event('input', { bubbles: true }));
   assert.equal(document.getElementById('docTitle').textContent, 'KT Intake');
   assert.equal(document.getElementById('docSubtitle').textContent, '');
-  assert.equal(document.getElementById('labelNow').textContent, 'What condition or behavior is observed for the affected item now?');
-  assert.equal(document.getElementById('labelHealthy').textContent, 'What condition or behavior is expected for the affected item?');
+  assert.equal(document.getElementById('labelNow').textContent, 'What is happening instead?');
+  assert.equal(document.getElementById('labelHealthy').textContent, 'What should normally happen?');
   assert.equal(document.title, 'KT Intake');
 
   objectISField.value = '';
@@ -199,8 +199,8 @@ test('preface: mirrors KT fields, normalises containment, and updates titles', a
   objectPrefill.dispatchEvent(new window.Event('input', { bubbles: true }));
   assert.equal(document.getElementById('docTitle').textContent, 'KT Intake');
   assert.equal(document.getElementById('docSubtitle').textContent, '');
-  assert.equal(document.getElementById('labelNow').textContent, 'What condition or behavior is observed for the affected item now?');
-  assert.equal(document.getElementById('labelHealthy').textContent, 'What condition or behavior is expected for the affected item?');
+  assert.equal(document.getElementById('labelNow').textContent, 'What is happening instead?');
+  assert.equal(document.getElementById('labelHealthy').textContent, 'What should normally happen?');
 
   applyPrefaceState({
     ops: { containStatus: 'mitigation' }

--- a/tests/summary.feature.test.mjs
+++ b/tests/summary.feature.test.mjs
@@ -380,15 +380,15 @@ test('summary: non-major modes use mode labels and exclude major-incident-only s
   const text = buildSummaryText(state);
 
   assert.ok(text.includes('— Technology Operations Summary —'));
-  assert.ok(text.includes('• What problem is affecting the service or system?: Checkout payments are failing'));
-  assert.ok(text.includes('• Which system is affected?: Payments API'));
+  assert.ok(text.includes('• What service or system is affected, and what is it doing wrong?: Checkout payments are failing'));
+  assert.ok(text.includes('• What specific system or service is affected?: Payments API'));
   assert.ok(!text.includes('Operational evidence'));
   assert.ok(!text.includes('Synthetic monitor and logs confirm errors'));
   assert.ok(!text.includes('Detection Source'));
   assert.ok(!text.includes('Evidence Collected'));
-  assert.ok(text.includes('What is the current user or system impact?: Customers cannot complete checkout'));
-  assert.ok(text.includes('What future operational impact is likely if unresolved?: Backlog may trigger order cancellations'));
-  assert.ok(text.includes('When is action or resolution needed to avoid additional impact?: Detected at 12:45 UTC'));
+  assert.ok(text.includes('Who or what is affected right now?: Customers cannot complete checkout'));
+  assert.ok(text.includes('What additional impact could occur if the incident continues?: Backlog may trigger order cancellations'));
+  assert.ok(text.includes('Timeframe: Detected at 12:45 UTC'));
   assert.ok(text.includes('— Problem Analysis —'));
   assert.ok(text.includes('— Possible Causes —'));
   assert.ok(text.includes('Likely Cause:'));


### PR DESCRIPTION
### Motivation

- Simplify and standardize intake prompts so each controlled field shows a single-question label and concise directive helper text across modes to improve clarity for operators. 
- Make the summary output use a stable, human-friendly label for the impact timeframe section. 
- Align unit and feature tests with the updated copy and behavioral expectations.

### Description

- Rewrote the caption overrides in `src/intakeModes.js` for `GENERAL`, `IT`, `PHARMA`, and `MAJOR_INCIDENT` modes to simplified single-question labels. 
- Rewrote the helper-text overrides in `src/intakeModes.js` to concise guidance phrasing paired with the new question labels. 
- Kept `INTAKE_MODE_FIELD_CAPTIONS` construction intact (it still derives labels/helpers/subtitles/placeholders from the override maps). 
- Changed the summary generation in `src/summary.js` to render the impact timeframe line with the fixed label `Timeframe` instead of using the caption lookup. 
- Updated many test expectations and added stricter tests in `tests/intakeModes.unit.test.mjs`, `tests/intakeModeController.unit.test.mjs`, `tests/preface.feature.test.mjs`, and `tests/summary.feature.test.mjs` to assert the new labels, helpers, and summary output, and to validate that labels are questions and helpers are directive guidance.

### Testing

- Ran unit tests including `tests/intakeModes.unit.test.mjs` and `tests/intakeModeController.unit.test.mjs`, which now assert exact label/helper strings and pass. 
- Ran feature/spec tests including `tests/preface.feature.test.mjs` and `tests/summary.feature.test.mjs` to confirm DOM-rendered labels and generated summary text reflect the new copy and these tests pass. 
- All modified automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a618f3e09108324827fb2745b0747ce)