### PR TITLE
Preserve sentence case in Impact headings

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -787,6 +787,7 @@ fieldset.field legend{font-weight:700; margin-bottom:6px; font-size:14px; color:
   font-size:17px;
   font-weight:700;
   letter-spacing:-0.02em;
+  text-transform:none;
   color:#1f2b40;
   font-family:"SF Pro Display","SF Pro Text",-apple-system,system-ui,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
 }
@@ -796,6 +797,7 @@ fieldset.field legend{font-weight:700; margin-bottom:6px; font-size:14px; color:
   font-size:15px;
   font-weight:600;
   letter-spacing:-0.015em;
+  text-transform:none;
   color:#22324b;
   font-family:"SF Pro Display","SF Pro Text",-apple-system,system-ui,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
 }

--- a/tests/impactHeadings.dom.test.mjs
+++ b/tests/impactHeadings.dom.test.mjs
@@ -1,0 +1,56 @@
+/**
+ * @fileoverview CSS regression coverage for the Impact prompt heading casing.
+ *
+ * Loads the intake markup and shared stylesheet into jsdom so the test can
+ * verify that the Impact-specific heading rules override `.card h3`.
+ */
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import { JSDOM } from 'jsdom';
+
+const INDEX_HTML = readFileSync(new URL('../index.html', import.meta.url), 'utf8');
+const STYLES = readFileSync(new URL('../styles.css', import.meta.url), 'utf8');
+const IMPACT_PROMPT_IDS = [
+  'impactNowHeading',
+  'impactFutureHeading',
+  'impactTimeHeading'
+];
+
+/**
+ * Builds the intake document with the production stylesheet available to CSSOM.
+ *
+ * @returns {Document} The static, styled intake document.
+ */
+function buildStyledIndexDocument() {
+  const dom = new JSDOM(INDEX_HTML);
+  const style = dom.window.document.createElement('style');
+
+  style.textContent = STYLES;
+  dom.window.document.head.append(style);
+
+  return dom.window.document;
+}
+
+test('Impact prompt headings preserve sentence case instead of card heading uppercase styling', () => {
+  const document = buildStyledIndexDocument();
+  const impactTitle = document.querySelector('.impact > h3');
+
+  assert.ok(impactTitle, 'expected the Impact card title to remain a direct heading child');
+  assert.equal(
+    document.defaultView.getComputedStyle(impactTitle).textTransform,
+    'none',
+    'expected the .impact > h3 rule to override the shared .card h3 uppercase treatment'
+  );
+
+  for (const headingId of IMPACT_PROMPT_IDS) {
+    const heading = document.getElementById(headingId);
+
+    assert.ok(heading, `expected #${headingId} to remain in the Impact card`);
+    assert.equal(
+      document.defaultView.getComputedStyle(heading).textTransform,
+      'none',
+      `expected #${headingId} to override the shared .card h3 uppercase treatment`
+    );
+  }
+});


### PR DESCRIPTION
### Motivation
- The shared `.card h3` rule uppercased headings site-wide and unintentionally affected the Impact card; the intent is to keep Impact prompts and the card title in sentence case while preserving their existing typography.

### Description
- Add `text-transform: none` to `.impact > h3` and `.impact .field h3` in `styles.css` so the Impact card title and prompt headings do not inherit the global `.card h3` uppercase styling.
- Add a DOM/CSS regression test `tests/impactHeadings.dom.test.mjs` that loads `index.html` and `styles.css` into `jsdom` and asserts the Impact card title and the three prompt headings (`#impactNowHeading`, `#impactFutureHeading`, `#impactTimeHeading`) compute `text-transform: none`.

### Testing
- Ran the focused DOM test with `node --test --loader ./tests/test-loader.mjs tests/impactHeadings.dom.test.mjs` and it passed. 
- Ran lint with `npm run lint` and it passed. 
- Executed the repository coverage guard with `npm run verify:tests`, which completed without reporting missing test coverage for the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a61a458e5988324b610e80f35d2f789)