### PR TITLE
Align header with desktop intake content

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -632,7 +632,8 @@ body.comms-drawer-open{overflow:hidden;}
 .notes-workspace__list{display:flex; flex-direction:column; gap:8px; list-style:none; margin:16px 0 0; padding:0;}
 .notes-workspace__item{display:flex; align-items:center; gap:8px; padding:10px; border:1px solid var(--line); border-radius:10px; background:var(--panel-muted); cursor:grab;}.notes-workspace__text{flex:1; overflow-wrap:anywhere; font-size:13px; line-height:1.35;}.notes-workspace__empty{color:var(--muted); font-size:13px;}
 .notes-workspace :is(button,input,.notes-workspace__item):focus{outline:none; border-color:var(--accent); box-shadow:0 0 0 3px var(--focus-ring);}
-@media (min-width:921px){.wrap{margin-right:340px;}.site-footer{margin-right:340px;}}
+/* Reserve the notes dock across every primary content region so their edges stay aligned at browser zoom levels. */
+@media (min-width:921px){header,.wrap{margin-right:340px;}.site-footer{margin-right:340px;}}
 @media (max-width:920px){.notes-workspace{top:auto; bottom:16px; right:16px; width:min(360px,calc(100vw - 32px)); max-height:min(55vh,440px);}.notes-workspace.is-collapsed{max-height:54px; overflow:hidden;}.notes-workspace.is-collapsed .notes-workspace__header p{display:none;}}
 
 .site-footer{

--- a/tests/desktopContentAlignment.feature.test.mjs
+++ b/tests/desktopContentAlignment.feature.test.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+
+const STYLES = readFileSync(new URL('../styles.css', import.meta.url), 'utf8');
+
+test('desktop header and intake content reserve the same notes workspace gutter', () => {
+  const desktopLayoutRule = STYLES.match(
+    /@media\s*\(min-width:921px\)\s*\{\s*header\s*,\s*\.wrap\s*\{\s*margin-right\s*:\s*340px\s*;?\s*\}/
+  );
+
+  assert.ok(
+    desktopLayoutRule,
+    'header and .wrap should share the notes workspace gutter to remain horizontally aligned'
+  );
+});


### PR DESCRIPTION
### Motivation
- The header was visually misaligned from the main intake content at certain zoom levels because the notes workspace dock was only reserving space for `.wrap` and not the `header`. 
- Reserve the same right-side gutter for the header so the menu bar and page content remain horizontally aligned across desktop viewports. 

### Description
- Update `styles.css` to include `header` in the desktop gutter rule so `header`, `.wrap`, and `.site-footer` share `margin-right:340px` under `@media (min-width:921px)` and add an explanatory comment. 
- Add a regression test `tests/desktopContentAlignment.feature.test.mjs` that asserts the shared desktop alignment CSS rule exists in `styles.css`. 
- Keep change minimal and scoped to layout CSS and a small feature test to avoid touching anchors or runtime behaviour. 

### Testing
- Ran the focused test with `npm test -- tests/desktopContentAlignment.feature.test.mjs`, which passed. 
- Ran the full test suite and linter with `npm test` and `npm run lint`, and the CI-local run completed with no failing tests (104 tests total, 103 passed, 0 failed, 1 skipped) and no lint errors. 
- Verified `git diff --check` returned clean results after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a63af572c348324a699edd64aabe801)