### PR TITLE
Scope page header layout rules to top-level header to fix Notes workspace alignment

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -74,7 +74,7 @@ body{
   transition:background-color var(--speed), color var(--speed);
 }
 body.theme-dark,body[data-theme="dark"]{color-scheme:dark;}
-header{
+body > header{
   max-width:1240px; margin:26px auto 12px; padding:0 12px;
   display:flex; flex-direction:column; gap:18px;
 }
@@ -184,7 +184,7 @@ h1#docTitle{font-size:22px; font-weight:800; margin:0; letter-spacing:-0.01em; w
   font-variant-numeric:tabular-nums;
 }
 @media(max-width:640px){
-  header{padding:0 16px;}
+  body > header{padding:0 16px;}
   .menu-bar{padding:12px;}
   .menu-bar .intake-mode-selector{flex:1 1 100%; padding:0 0 12px; border-right:0; border-bottom:1px solid var(--line);}
   .menu-bar .intake-mode-selector small{max-width:none;}
@@ -633,7 +633,7 @@ body.comms-drawer-open{overflow:hidden;}
 .notes-workspace__item{display:flex; align-items:center; gap:8px; padding:10px; border:1px solid var(--line); border-radius:10px; background:var(--panel-muted); cursor:grab;}.notes-workspace__text{flex:1; overflow-wrap:anywhere; font-size:13px; line-height:1.35;}.notes-workspace__empty{color:var(--muted); font-size:13px;}
 .notes-workspace :is(button,input,.notes-workspace__item):focus{outline:none; border-color:var(--accent); box-shadow:0 0 0 3px var(--focus-ring);}
 /* Reserve the notes dock across every primary content region so their edges stay aligned at browser zoom levels. */
-@media (min-width:921px){header,.wrap{margin-right:340px;}.site-footer{margin-right:340px;}}
+@media (min-width:921px){body > header,.wrap{margin-right:340px;}.site-footer{margin-right:340px;}}
 @media (max-width:920px){.notes-workspace{top:auto; bottom:16px; right:16px; width:min(360px,calc(100vw - 32px)); max-height:min(55vh,440px);}.notes-workspace.is-collapsed{max-height:54px; overflow:hidden;}.notes-workspace.is-collapsed .notes-workspace__header p{display:none;}}
 
 .site-footer{

--- a/tests/desktopContentAlignment.feature.test.mjs
+++ b/tests/desktopContentAlignment.feature.test.mjs
@@ -4,13 +4,18 @@ import { test } from 'node:test';
 
 const STYLES = readFileSync(new URL('../styles.css', import.meta.url), 'utf8');
 
-test('desktop header and intake content reserve the same notes workspace gutter', () => {
+test('desktop page header and intake content reserve the same notes workspace gutter', () => {
   const desktopLayoutRule = STYLES.match(
-    /@media\s*\(min-width:921px\)\s*\{\s*header\s*,\s*\.wrap\s*\{\s*margin-right\s*:\s*340px\s*;?\s*\}/
+    /@media\s*\(min-width:921px\)\s*\{\s*body\s*>\s*header\s*,\s*\.wrap\s*\{\s*margin-right\s*:\s*340px\s*;?\s*\}/
   );
 
   assert.ok(
     desktopLayoutRule,
-    'header and .wrap should share the notes workspace gutter to remain horizontally aligned'
+    'the page header and .wrap should share the notes workspace gutter to remain horizontally aligned'
   );
+});
+
+test('notes workspace header is excluded from page header layout rules', () => {
+  assert.doesNotMatch(STYLES, /(?:^|\n)header\s*\{/u);
+  assert.doesNotMatch(STYLES, /\{\s*header\s*,\s*\.wrap\s*\{/u);
 });


### PR DESCRIPTION
### Motivation
- The Notes Workspace header was unintentionally affected by broad `header` CSS rules, causing the dock to display incorrectly relative to the page header. 
- The intent is to keep the desktop notes-dock gutter aligned with the page header and .wrap while excluding nested headers inside the dock from those layout rules.

### Description
- Replace generic `header` selectors with `body > header` in `styles.css` so layout and padding rules only target the top-level page header. 
- Update the desktop gutter media query to use `body > header,.wrap{margin-right:340px;}` so the reserved notes workspace width applies only to the page header and main content. 
- Add regression coverage in `tests/desktopContentAlignment.feature.test.mjs` that verifies the scoped gutter rule and asserts that the Notes Workspace header is not matched by the broad `header` selectors. 

### Testing
- Ran `npm test -- tests/desktopContentAlignment.feature.test.mjs` and the new assertions passed. 
- Ran `npm run lint` and it completed successfully. 
- Ran `npm run verify:tests` which completed successfully and confirmed test coverage for the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a63b2cf2098832483f1b6b36084b8ea)