### PR TITLE
Add Major Incident KT ownership metadata

### DIFF
--- a/src/intakeModes.js
+++ b/src/intakeModes.js
@@ -9,6 +9,8 @@
  *   `src/constants.js`.
  */
 
+import { ROWS } from './constants.js';
+
 /**
  * Recursively freezes an intake-mode configuration object.
  *
@@ -78,6 +80,124 @@ export const INTAKE_MODES = deepFreeze([
   { id: INTAKE_MODE_IDS.PHARMA, label: INTAKE_MODE_LABELS[INTAKE_MODE_IDS.PHARMA] },
   { id: INTAKE_MODE_IDS.MAJOR_INCIDENT, label: INTAKE_MODE_LABELS[INTAKE_MODE_IDS.MAJOR_INCIDENT] }
 ]);
+
+/**
+ * Major-Incident KT phases, including their semantic colour and accountability
+ * guidance. Participation labels are intentionally explicit so consumers do
+ * not need to infer ownership from a phase colour.
+ *
+ * @type {ReadonlyArray<Readonly<{
+ *   id: string,
+ *   label: string,
+ *   color: string,
+ *   purpose: string,
+ *   primaryRespondent: Readonly<{ participation: 'Primary responder', role: string }>,
+ *   supportingRoles: ReadonlyArray<Readonly<{ participation: 'Consult', role: string }>>,
+ *   approvalDecisionRole: Readonly<{ participation: 'Approves', role: string }>
+ * }>>}
+ */
+export const MAJOR_INCIDENT_KT_PHASES = deepFreeze([
+  {
+    id: 'situationAppraisal',
+    label: 'Situation Appraisal',
+    color: 'blue',
+    purpose: 'Establishes impact, urgency, priorities, containment status, bridge coordination, and communications.',
+    primaryRespondent: { participation: 'Primary responder', role: 'Incident Manager / Incident Commander' },
+    supportingRoles: [
+      { participation: 'Consult', role: 'Communications Lead' },
+      { participation: 'Consult', role: 'Technical Bridge Lead' }
+    ],
+    approvalDecisionRole: { participation: 'Approves', role: 'Incident Manager / Incident Commander' }
+  },
+  {
+    id: 'problemAnalysis',
+    label: 'Problem Analysis',
+    color: 'red',
+    purpose: 'Supplies factual IS / IS NOT evidence, distinctions, changes, and tests possible causes.',
+    primaryRespondent: { participation: 'Primary responder', role: 'Subject-Matter Expert' },
+    supportingRoles: [
+      { participation: 'Consult', role: 'Incident Manager / Incident Commander' },
+      { participation: 'Consult', role: 'Technical Bridge Lead' }
+    ],
+    approvalDecisionRole: { participation: 'Approves', role: 'Application Owner or delegated business/service owner' }
+  },
+  {
+    id: 'decisionAnalysis',
+    label: 'Decision Analysis',
+    color: 'green',
+    purpose: 'Selects and authorizes the preferred mitigation or recovery decision after SME input.',
+    primaryRespondent: { participation: 'Primary responder', role: 'Application Owner or delegated business/service owner' },
+    supportingRoles: [
+      { participation: 'Consult', role: 'Subject-Matter Expert' },
+      { participation: 'Consult', role: 'Incident Manager / Incident Commander' }
+    ],
+    approvalDecisionRole: { participation: 'Approves', role: 'Application Owner or delegated business/service owner' }
+  },
+  {
+    id: 'potentialProblemAnalysis',
+    label: 'Potential Problem Analysis',
+    color: 'orange',
+    purpose: 'Assesses implementation risk, controls, rollback, and contingency actions.',
+    primaryRespondent: { participation: 'Primary responder', role: 'Change Manager' },
+    supportingRoles: [
+      { participation: 'Consult', role: 'Subject-Matter Expert' },
+      { participation: 'Consult', role: 'Application Owner or delegated business/service owner' }
+    ],
+    approvalDecisionRole: { participation: 'Approves', role: 'Change Manager' }
+  }
+]);
+
+const MAJOR_INCIDENT_PHASE_BY_ID = Object.fromEntries(
+  MAJOR_INCIDENT_KT_PHASES.map((phase) => [phase.id, phase])
+);
+
+const KT_PROBLEM_ANALYSIS_QUESTION_IDS = deepFreeze(
+  ROWS.flatMap((row) => (typeof row.id === 'string' ? [row.id] : []))
+);
+
+/**
+ * Major-Incident ownership metadata keyed by the stable workflow-area IDs used
+ * by `data-mode-section`. KT row IDs remain owned by the immutable `ROWS`
+ * collection; the `problemAnalysis` area associates those existing IDs with
+ * Problem Analysis here rather than changing the question definitions.
+ *
+ * @type {Readonly<Record<string, Readonly<{
+ *   phase: Readonly<{ id: string, label: string, color: string, purpose: string }>,
+ *   primaryRespondent: Readonly<{ participation: 'Primary responder', role: string }>,
+ *   supportingRoles: ReadonlyArray<Readonly<{ participation: 'Consult', role: string }>>,
+ *   approvalDecisionRole: Readonly<{ participation: 'Approves', role: string }>,
+ *   questionIds?: ReadonlyArray<string>
+ * }>>>}
+ */
+export const MAJOR_INCIDENT_WORKFLOW_METADATA = deepFreeze(Object.fromEntries([
+  ['problemSummary', 'situationAppraisal'],
+  ['collaboration', 'situationAppraisal'],
+  ['detectionSource', 'situationAppraisal'],
+  ['evidenceCollected', 'situationAppraisal'],
+  ['incidentProof', 'situationAppraisal'],
+  ['impact', 'situationAppraisal'],
+  ['containment', 'situationAppraisal'],
+  ['communications', 'situationAppraisal'],
+  ['problemAnalysis', 'problemAnalysis'],
+  ['possibleCauses', 'problemAnalysis'],
+  ['actions', 'decisionAnalysis'],
+  ['steps', 'potentialProblemAnalysis'],
+  ['handover', 'potentialProblemAnalysis']
+].map(([workflowArea, phaseId]) => {
+  const phase = MAJOR_INCIDENT_PHASE_BY_ID[phaseId];
+  return [workflowArea, {
+    phase: {
+      id: phase.id,
+      label: phase.label,
+      color: phase.color,
+      purpose: phase.purpose
+    },
+    primaryRespondent: phase.primaryRespondent,
+    supportingRoles: phase.supportingRoles,
+    approvalDecisionRole: phase.approvalDecisionRole,
+    ...(workflowArea === 'problemAnalysis' ? { questionIds: KT_PROBLEM_ANALYSIS_QUESTION_IDS } : {})
+  }];
+})));
 
 const ALL_SECTIONS_VISIBLE = deepFreeze({
   problemSummary: true,

--- a/tests/intakeModes.unit.test.mjs
+++ b/tests/intakeModes.unit.test.mjs
@@ -4,6 +4,8 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
+import { ROWS } from '../src/constants.js';
+
 import {
   DEFAULT_INTAKE_MODE,
   INTAKE_MODE_CAPTION_OVERRIDES,
@@ -12,7 +14,9 @@ import {
   INTAKE_MODE_IDS,
   INTAKE_MODE_LABELS,
   INTAKE_MODE_SECTION_VISIBILITY,
-  INTAKE_MODES
+  INTAKE_MODES,
+  MAJOR_INCIDENT_KT_PHASES,
+  MAJOR_INCIDENT_WORKFLOW_METADATA
 } from '../src/intakeModes.js';
 
 const REQUIRED_FIELD_IDS = ['oneLine', 'proof', 'objectPrefill', 'healthy', 'now', 'impactNow', 'impactFuture', 'impactTime'];
@@ -51,6 +55,38 @@ test('each intake mode declares visibility for every known workflow section', ()
     assert.deepEqual(Object.keys(INTAKE_MODE_SECTION_VISIBILITY[modeId]).sort(), [...REQUIRED_SECTION_IDS].sort());
   });
   assert.ok(Object.values(INTAKE_MODE_SECTION_VISIBILITY[INTAKE_MODE_IDS.MAJOR_INCIDENT]).every(Boolean));
+});
+
+test('Major Incident workflow metadata assigns every area a semantic KT phase and explicit participation', () => {
+  assert.deepEqual(Object.keys(MAJOR_INCIDENT_WORKFLOW_METADATA).sort(), [...REQUIRED_SECTION_IDS].sort());
+  assert.deepEqual(
+    MAJOR_INCIDENT_KT_PHASES.map(({ id, label, color }) => [id, label, color]),
+    [
+      ['situationAppraisal', 'Situation Appraisal', 'blue'],
+      ['problemAnalysis', 'Problem Analysis', 'red'],
+      ['decisionAnalysis', 'Decision Analysis', 'green'],
+      ['potentialProblemAnalysis', 'Potential Problem Analysis', 'orange']
+    ]
+  );
+
+  Object.values(MAJOR_INCIDENT_WORKFLOW_METADATA).forEach((area) => {
+    assert.match(area.phase.purpose, /.+/);
+    assert.equal(area.primaryRespondent.participation, 'Primary responder');
+    assert.ok(area.supportingRoles.length > 0);
+    area.supportingRoles.forEach((role) => assert.equal(role.participation, 'Consult'));
+    assert.equal(area.approvalDecisionRole.participation, 'Approves');
+  });
+});
+
+test('Major Incident metadata maps protected KT row IDs to Problem Analysis without changing ROWS', () => {
+  const questionIds = ROWS.flatMap((row) => (row.id ? [row.id] : []));
+  const problemAnalysis = MAJOR_INCIDENT_WORKFLOW_METADATA.problemAnalysis;
+
+  assert.equal(problemAnalysis.phase.id, 'problemAnalysis');
+  assert.deepEqual(problemAnalysis.questionIds, questionIds);
+  assert.ok(Object.isFrozen(MAJOR_INCIDENT_WORKFLOW_METADATA));
+  assert.ok(Object.isFrozen(problemAnalysis.questionIds));
+  assert.ok(Object.isFrozen(ROWS));
 });
 
 test('caption and helper override maps preserve stable field IDs for every mode', () => {


### PR DESCRIPTION
### Motivation
- Provide immutable, queryable Major Incident–specific metadata that maps workflow areas to KT phases and explicitly documents who should respond, consult, and approve decisions. 
- Preserve the protected `ROWS` in `src/constants.js` while associating its existing KT question IDs with the Problem Analysis phase rather than modifying those prompts.

### Description
- Added `MAJOR_INCIDENT_KT_PHASES` (deep-frozen) defining the four semantic phases with colours, purpose text, and explicit participation labels: `Primary responder`, `Consult`, and `Approves`.
- Added `MAJOR_INCIDENT_WORKFLOW_METADATA` (deep-frozen) mapping each existing workflow area (e.g., `problemSummary`, `problemAnalysis`, `possibleCauses`, `steps`, `handover`) to the appropriate phase and returning the phase-level `primaryRespondent`, `supportingRoles`, and `approvalDecisionRole` information.
- Imported `ROWS` from `src/constants.js` and exposed `KT_PROBLEM_ANALYSIS_QUESTION_IDS` that collects the protected question IDs and is attached to the `problemAnalysis` workflow area without mutating `ROWS`.
- Exposed the new constants from `src/intakeModes.js` so consumers can render phase badges, show role ownership, or drive decision workflows while relying on the existing immutable `deepFreeze` contract.

### Testing
- Added unit coverage in `tests/intakeModes.unit.test.mjs` verifying exported phase definitions, per-area participation metadata, deep immutability, and that the protected `ROWS` question IDs are associated with `problemAnalysis` without being changed.
- Ran the unit suite with `npm test -- tests/intakeModes.unit.test.mjs`, which passed.
- Ran the repository checks `npm run lint` and the coverage guard `npm run verify:tests`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a63c28e9f3c83248c661aecbf333c83)