### PR TITLE
Fix templates drawer header layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -534,10 +534,11 @@ body.templates-drawer-open{overflow:hidden;}
 .templates-drawer__header{
   padding:24px; border-bottom:1px solid #ecf0f8;
   background:linear-gradient(180deg,#fdfefe 0%,#f6f8fc 100%);
-  display:flex; justify-content:space-between; gap:16px; align-items:flex-start;
+  display:flex; flex-direction:column; gap:16px; align-items:stretch;
 }
 .templates-drawer__intro{flex:1; min-width:0;}
-.templates-drawer__controls{display:flex; flex-direction:column; gap:8px; align-items:stretch;}
+.templates-drawer__controls{display:flex; flex-wrap:wrap; gap:12px; align-items:center; justify-content:space-between;}
+.templates-drawer__controls .btn-secondary{flex:1 1 220px; min-width:0;}
 .templates-drawer__title{margin:0; font-size:19px; font-weight:700; letter-spacing:-0.01em;}
 .templates-drawer__subtitle{margin:6px 0 0; font-size:13px; color:var(--muted); line-height:1.5;}
 .templates-drawer__close-btn{
@@ -621,9 +622,6 @@ body.templates-drawer-open{overflow:hidden;}
 @media (max-width:720px){
   .templates-drawer{width:100%;}
   .templates-modes{grid-template-columns:1fr;}
-}
-@media (min-width:721px){
-  .templates-drawer__controls{flex-direction:row; align-items:center; justify-content:flex-end; gap:12px;}
 }
 .comms-backdrop{z-index:85;}
 .comms-drawer{

--- a/tests/templatesDrawer.layout.test.mjs
+++ b/tests/templatesDrawer.layout.test.mjs
@@ -1,0 +1,29 @@
+/**
+ * Templates drawer layout regression coverage.
+ *
+ * Verifies that the drawer header preserves a full-width introduction above
+ * its wrapping action row, regardless of the viewport outside the drawer.
+ */
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { test } from 'node:test';
+
+test('templates drawer: header actions cannot squeeze the introduction column', async () => {
+  const styles = await readFile(new URL('../styles.css', import.meta.url), 'utf8');
+
+  assert.match(
+    styles,
+    /\.templates-drawer__header\s*\{[^}]*flex-direction:column;[^}]*align-items:stretch;/u,
+    'the introduction and controls should occupy separate rows'
+  );
+  assert.match(
+    styles,
+    /\.templates-drawer__controls\s*\{[^}]*flex-wrap:wrap;[^}]*justify-content:space-between;/u,
+    'drawer actions should wrap instead of overflowing or compressing nearby copy'
+  );
+  assert.match(
+    styles,
+    /\.templates-drawer__controls \.btn-secondary\s*\{[^}]*flex:1 1 220px;[^}]*min-width:0;/u,
+    'the long save action should shrink and wrap safely within the drawer'
+  );
+});


### PR DESCRIPTION
### Motivation
- The templates drawer header could be squeezed by long action controls after the notes workspace became persistent, causing the title/subtitle to compress on the top row. 
- The intent is to keep the introduction (title + subtitle) full-width and let the action row wrap/shrink without overlapping or compressing nearby copy.

### Description
- Change the header layout to stack the intro above the actions by setting `.templates-drawer__header` to `flex-direction: column` and `align-items: stretch` in `styles.css`.
- Make the actions row responsive by allowing `.templates-drawer__controls` to `flex-wrap: wrap`, `justify-content: space-between`, and add a shrinkable rule for the save button with `.templates-drawer__controls .btn-secondary { flex:1 1 220px; min-width:0; }`.
- Remove the narrower media-query-based control layout and instead rely on wrapping to avoid squeezing the intro column at varied viewport widths.
- Add regression coverage `tests/templatesDrawer.layout.test.mjs` to assert the header layout contract in `styles.css`.

### Testing
- Ran the new test with `npm test -- tests/templatesDrawer.layout.test.mjs` and the suite covering the new file passed.
- Ran the full test harness via `npm test` which reported automated results: 132 passed, 1 skipped (no failures).
- Ran `npm run lint` and `npm run verify:tests` and both checks completed successfully with no errors reported.
- Attempted to install Chromium for visual/screenshot checks (`npx playwright install chromium`), but the environment rejected the Playwright download with an HTTP 403 from the registry so screenshot-based verification was not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a679b19c9548324b001432372e0ffe6)